### PR TITLE
Use Zulip ID instead of e-mail for most things

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -24,7 +24,7 @@ func (ra *RecurseAPI) userIsCurrentlyAtRC(accessToken string, email string) bool
 	return contains(emailsOfPeopleAtRC, email)
 }
 
-//The profile API endpoint is updated at midnight on the last day (Friday) of a batch.
+// The profile API endpoint is updated at midnight on the last day (Friday) of a batch.
 func (ra *RecurseAPI) getCurrentlyActiveEmails(accessToken string) []string {
 	var emailsOfPeopleAtRC []string
 	offset := 0
@@ -56,8 +56,8 @@ func (ra *RecurseAPI) getCurrentlyActiveEmails(accessToken string) []string {
 }
 
 /*
-	The RC API limits queries to the profiles endpoint to 50 results. However, there may be more than 50 people currently at RC.
-	The RC API takes in an "offset" query param that allows us to grab records beyond that limit of 50 results by performing multiple api calls.
+The RC API limits queries to the profiles endpoint to 50 results. However, there may be more than 50 people currently at RC.
+The RC API takes in an "offset" query param that allows us to grab records beyond that limit of 50 results by performing multiple api calls.
 */
 func (ra *RecurseAPI) getCurrentlyActiveEmailsWithOffset(accessToken string, offset int, limit int) []string {
 	var emailsOfPeopleAtRC []string
@@ -71,7 +71,7 @@ func (ra *RecurseAPI) getCurrentlyActiveEmailsWithOffset(accessToken string, off
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		log.Printf("Unable to get the emails of people currently at RC due to the following error: %s", err)
@@ -98,7 +98,7 @@ func (ra *RecurseAPI) isSecondWeekOfBatch(accessToken string) bool {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	//Parse the json response from the API
 	var batches []map[string]interface{}

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ type userRequest interface {
 }
 
 type userNotification interface {
-	sendUserMessage(ctx context.Context, botPassword, user, message string) error
+	sendUserMessage(ctx context.Context, botPassword string, userIDs []int64, message string) error
 }
 
 type streamMessage interface {
@@ -119,12 +119,14 @@ func (zsm *zulipStreamMessage) postToTopic(ctx context.Context, botPassword, mes
 	return nil
 }
 
-func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPassword, user, message string) error {
+func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPassword string, userIDs []int64, message string) error {
 
 	zulipClient := &http.Client{}
 	messageRequest := url.Values{}
 	messageRequest.Add("type", "private")
-	messageRequest.Add("to", user)
+	for _, id := range userIDs {
+		messageRequest.Add("to", fmt.Sprintf("%d", id))
+	}
 	messageRequest.Add("content", message)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", zun.zulipAPIURL, strings.NewReader(messageRequest.Encode()))
@@ -215,7 +217,7 @@ type mockUserRequest struct {
 type mockUserNotification struct {
 }
 
-func (mun *mockUserNotification) sendUserMessage(ctx context.Context, botPassword, user, message string) error {
+func (mun *mockUserNotification) sendUserMessage(ctx context.Context, botPassword string, userIDs []int64, message string) error {
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -28,7 +27,7 @@ type incomingJSON struct {
 }
 
 type UserDataFromJSON struct {
-	userID    string
+	userID    int64
 	userEmail string
 	userName  string
 }
@@ -200,7 +199,7 @@ func (zur *zulipUserRequest) getCommandString() string {
 
 func (zur *zulipUserRequest) extractUserData() *UserDataFromJSON {
 	return &UserDataFromJSON{
-		userID:    strconv.Itoa(zur.json.Message.SenderID),
+		userID:    int64(zur.json.Message.SenderID),
 		userEmail: zur.json.Message.SenderEmail,
 		userName:  zur.json.Message.SenderFullName,
 	}

--- a/database.go
+++ b/database.go
@@ -447,8 +447,6 @@ func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {
 		return Review{}, err
 	}
 
-	rand.Seed(time.Now().Unix())
-
 	return allReviews[rand.Intn(len(allReviews))], nil
 }
 

--- a/dispatch.go
+++ b/dispatch.go
@@ -27,7 +27,7 @@ const notSubscribedMessage string = "You're not subscribed to Pairing Bot <3"
 var writeErrorMessage = fmt.Sprintf("Something went sideways while writing to the database. You should probably ping %v", owner)
 var readErrorMessage = fmt.Sprintf("Something went sideways while reading from the database. You should probably ping %v", owner)
 
-func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []string, userID string, userEmail string, userName string) (string, error) {
+func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []string, userID int64, userEmail string, userName string) (string, error) {
 	var response string
 	var err error
 
@@ -82,7 +82,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 			log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
 		}
 
-		rec.currentlyAtRC = pl.rcapi.userIsCurrentlyAtRC(accessToken, userEmail)
+		rec.currentlyAtRC = pl.rcapi.userIsCurrentlyAtRC(accessToken, userID)
 
 		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -18,7 +18,7 @@ var maintenanceMode = false
 
 // this is the "id" field from zulip, and is a permanent user ID that's not secret
 // Pairing Bot's owner can add their ID here for testing. ctrl+f "ownerID" to see where it's used
-const ownerID = "215391"
+const ownerID = 215391
 
 type PairingLogic struct {
 	rdb   RecurserDB
@@ -88,7 +88,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	log.Printf("The user: %s issued the following request to Pairing Bot: %s", userData.userEmail, pl.ur.getCommandString())
+	log.Printf("The user: %s (%d) issued the following request to Pairing Bot: %s", userData.userName, userData.userID, pl.ur.getCommandString())
 
 	// you *should* be able to throw any string at this thing and get back a valid command for dispatch()
 	// if there are no command arguments, cmdArgs will be nil
@@ -98,7 +98,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// the tofu and potatoes right here y'all
-	response, err := dispatch(ctx, pl, cmd, cmdArgs, userData.userID, userData.userEmail, userData.userName)
+	response, err := dispatch(ctx, pl, cmd, cmdArgs, int64(userData.userID), userData.userEmail, userData.userName)
 	if err != nil {
 		log.Println(err)
 	}
@@ -213,7 +213,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
 	}
 
-	emailsOfPeopleAtRc := pl.rcapi.getCurrentlyActiveEmails(accessToken)
+	idsOfPeopleAtRc := pl.rcapi.getCurrentlyActiveZulipIds(accessToken)
 
 	for i := 0; i < len(recursersList); i++ {
 
@@ -222,7 +222,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 		recurserEmail := recurser.email
 		recurserID := recurser.id
 
-		isAtRCThisWeek := contains(emailsOfPeopleAtRc, recurserEmail)
+		isAtRCThisWeek := contains(idsOfPeopleAtRc, recurserID)
 		wasAtRCLastWeek := recursersList[i].currentlyAtRC
 
 		log.Printf("User: %s was at RC last week: %t and is at RC this week: %t", recurserEmail, wasAtRCLastWeek, isAtRCThisWeek)

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -127,9 +127,9 @@ func parseCmd(cmdStr string) (string, []string, error) {
 	}
 }
 
-func contains(list []string, cmd string) bool {
+func contains[S ~[]E, E comparable](list S, element E) bool {
 	for _, v := range list {
-		if v == cmd {
+		if v == element {
 			return true
 		}
 	}


### PR DESCRIPTION
Move towards using Zulip IDs instead of e-mails:

- Perform end-of-batch cleanup based on Zulip user ID rather than e-mail address
- Internally to the pairing database, consider "user ID" an int64 rather than a string
- Send messages based on user-ID rather than e-mail

And some cleanups:

- Cleanup: ioutil.ReadAll -> io.ReadAll
- Remove deprecated seeding of RNG
