### PR TITLE
Use Zulip ID instead of email for most purposes

### DIFF
--- a/api.go
+++ b/api.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -24,7 +24,7 @@ func (ra *RecurseAPI) userIsCurrentlyAtRC(accessToken string, email string) bool
 	return contains(emailsOfPeopleAtRC, email)
 }
 
-//The profile API endpoint is updated at midnight on the last day (Friday) of a batch.
+// The profile API endpoint is updated at midnight on the last day (Friday) of a batch.
 func (ra *RecurseAPI) getCurrentlyActiveEmails(accessToken string) []string {
 	var emailsOfPeopleAtRC []string
 	offset := 0
@@ -56,8 +56,8 @@ func (ra *RecurseAPI) getCurrentlyActiveEmails(accessToken string) []string {
 }
 
 /*
-	The RC API limits queries to the profiles endpoint to 50 results. However, there may be more than 50 people currently at RC.
-	The RC API takes in an "offset" query param that allows us to grab records beyond that limit of 50 results by performing multiple api calls.
+The RC API limits queries to the profiles endpoint to 50 results. However, there may be more than 50 people currently at RC.
+The RC API takes in an "offset" query param that allows us to grab records beyond that limit of 50 results by performing multiple api calls.
 */
 func (ra *RecurseAPI) getCurrentlyActiveEmailsWithOffset(accessToken string, offset int, limit int) []string {
 	var emailsOfPeopleAtRC []string
@@ -71,7 +71,7 @@ func (ra *RecurseAPI) getCurrentlyActiveEmailsWithOffset(accessToken string, off
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		log.Printf("Unable to get the emails of people currently at RC due to the following error: %s", err)
@@ -98,7 +98,7 @@ func (ra *RecurseAPI) isSecondWeekOfBatch(accessToken string) bool {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	//Parse the json response from the API
 	var batches []map[string]interface{}

--- a/api.go
+++ b/api.go
@@ -16,8 +16,7 @@ type RecurseAPI struct {
 
 type RecurserProfile struct {
 	Name    string
-	ZulipId int64
-	Email   string
+	ZulipId int64 `json:"zulip_id"`
 }
 
 func (ra *RecurseAPI) userIsCurrentlyAtRC(accessToken string, id int64) (bool, error) {

--- a/client.go
+++ b/client.go
@@ -128,7 +128,7 @@ func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPasswo
 	for _, id := range userIDs {
 		users = append(users, fmt.Sprint(id))
 	}
-	messageRequest.Add("to", strings.Join(users, ","))
+	messageRequest.Add("to", "["+strings.Join(users, ",")+"]")
 	messageRequest.Add("content", message)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", zun.zulipAPIURL, strings.NewReader(messageRequest.Encode()))

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ type userRequest interface {
 }
 
 type userNotification interface {
-	sendUserMessage(ctx context.Context, botPassword, user, message string) error
+	sendUserMessage(ctx context.Context, botPassword string, userIDs []int64, message string) error
 }
 
 type streamMessage interface {
@@ -119,12 +119,14 @@ func (zsm *zulipStreamMessage) postToTopic(ctx context.Context, botPassword, mes
 	return nil
 }
 
-func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPassword, user, message string) error {
+func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPassword string, userIDs []int64, message string) error {
 
 	zulipClient := &http.Client{}
 	messageRequest := url.Values{}
 	messageRequest.Add("type", "private")
-	messageRequest.Add("to", user)
+	for _, id := range userIDs {
+		messageRequest.Add("to", fmt.Sprintf("%d", id))
+	}
 	messageRequest.Add("content", message)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", zun.zulipAPIURL, strings.NewReader(messageRequest.Encode()))
@@ -215,7 +217,7 @@ type mockUserRequest struct {
 type mockUserNotification struct {
 }
 
-func (mun *mockUserNotification) sendUserMessage(ctx context.Context, botPassword, user, message string) error {
+func (mun *mockUserNotification) sendUserMessage(ctx context.Context, botPassword string, userIDs []int64, message string) error {
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -124,9 +124,11 @@ func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPasswo
 	zulipClient := &http.Client{}
 	messageRequest := url.Values{}
 	messageRequest.Add("type", "private")
+	users := []string{}
 	for _, id := range userIDs {
-		messageRequest.Add("to", fmt.Sprintf("%d", id))
+		users = append(users, fmt.Sprint(id))
 	}
+	messageRequest.Add("to", strings.Join(users, ","))
 	messageRequest.Add("content", message)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", zun.zulipAPIURL, strings.NewReader(messageRequest.Encode()))

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ type incomingJSON struct {
 	Token   string `json:"token"`
 	Trigger string `json:"trigger"`
 	Message struct {
-		SenderID         int         `json:"sender_id"`
+		SenderID         int64       `json:"sender_id"`
 		DisplayRecipient interface{} `json:"display_recipient"`
 		SenderEmail      string      `json:"sender_email"`
 		SenderFullName   string      `json:"sender_full_name"`

--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -28,7 +27,7 @@ type incomingJSON struct {
 }
 
 type UserDataFromJSON struct {
-	userID    string
+	userID    int64
 	userEmail string
 	userName  string
 }
@@ -200,7 +199,7 @@ func (zur *zulipUserRequest) getCommandString() string {
 
 func (zur *zulipUserRequest) extractUserData() *UserDataFromJSON {
 	return &UserDataFromJSON{
-		userID:    strconv.Itoa(zur.json.Message.SenderID),
+		userID:    int64(zur.json.Message.SenderID),
 		userEmail: zur.json.Message.SenderEmail,
 		userName:  zur.json.Message.SenderFullName,
 	}

--- a/database.go
+++ b/database.go
@@ -130,6 +130,7 @@ func (f *FirestoreRecurserDB) GetByUserID(ctx context.Context, userID int64, use
 	// also assign their email, for the same reason
 	if isSubscribed {
 		recurser := doc.Data()
+		recurser["id"] = userID
 		recurser["name"] = userName
 		recurser["email"] = userEmail
 		r, err = MapToStruct(recurser)

--- a/database.go
+++ b/database.go
@@ -447,8 +447,6 @@ func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {
 		return Review{}, err
 	}
 
-	rand.Seed(time.Now().Unix())
-
 	return allReviews[rand.Intn(len(allReviews))], nil
 }
 

--- a/database.go
+++ b/database.go
@@ -65,7 +65,8 @@ func MapToStruct(m map[string]interface{}) (Recurser, error) {
 	case uint:
 	case uint8:
 	case uint16:
-	case uint32:
+	case float32:
+	case float64:
 		id = int64(v)
 	case uint64:
 		if v > (1<<31)-1 {

--- a/database.go
+++ b/database.go
@@ -45,7 +45,6 @@ type Recurser struct {
 
 func (r *Recurser) ConvertToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"id":                 r.id,
 		"name":               r.name,
 		"email":              r.email,
 		"isSkippingTomorrow": r.isSkippingTomorrow,
@@ -54,44 +53,20 @@ func (r *Recurser) ConvertToMap() map[string]interface{} {
 	}
 }
 
-func MapToStruct(m map[string]interface{}) (Recurser, error) {
-	var id int64
-	switch v := m["id"].(type) {
-	case int:
-	case int8:
-	case int16:
-	case int32:
-	case int64:
-	case uint:
-	case uint8:
-	case uint16:
-	case float32:
-	case float64:
-		id = int64(v)
-	case uint64:
-		if v > (1<<31)-1 {
-			return Recurser{}, fmt.Errorf("ID value exceeds bounds: %d", v)
-		}
-		id = int64(v)
-	case string:
-		var err error
-		id, err = strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return Recurser{}, fmt.Errorf("invalid ID value: %w", err)
-		}
-	default:
-		return Recurser{}, fmt.Errorf("invalid ID value of type %T: %#v", m["id"], m["id"])
+func parseDoc(doc *firestore.DocumentSnapshot) (Recurser, error) {
+	id, err := strconv.ParseInt(doc.Ref.ID, 10, 64)
+	if err != nil {
+		return Recurser{}, fmt.Errorf("could not encode ID: %s as integer: %w", doc.Ref.ID, err)
+	}
+	var r Recurser
+	err = doc.DataTo(&r)
+	if err != nil {
+		return r, fmt.Errorf("could not decode Firestore data for entry %s: %w", doc.Ref.ID, err)
 	}
 
 	// isSubscribed is missing here because it's not in the map
-	return Recurser{
-		id:                 id,
-		name:               m["name"].(string),
-		email:              m["email"].(string),
-		isSkippingTomorrow: m["isSkippingTomorrow"].(bool),
-		schedule:           m["schedule"].(map[string]interface{}),
-		currentlyAtRC:      m["currentlyAtRC"].(bool),
-	}, nil
+	r.id = id
+	return r, nil
 }
 
 // DB Lookups of Pairing Bot subscribers (= "Recursers")
@@ -130,14 +105,15 @@ func (f *FirestoreRecurserDB) GetByUserID(ctx context.Context, userID int64, use
 	// also assign their zulip name to the name field, just in case it changed
 	// also assign their email, for the same reason
 	if isSubscribed {
-		recurser := doc.Data()
-		recurser["id"] = userID
-		recurser["name"] = userName
-		recurser["email"] = userEmail
-		r, err = MapToStruct(recurser)
+		r, err = parseDoc(doc)
 		if err != nil {
-			return Recurser{}, fmt.Errorf("getting database entry for recurser %s (ID: %d): %w", userName, userID, err)
+			log.Printf("error deserializing database entry with ID: %s: %s", doc.Ref.ID, err)
+			log.Printf("skipping database entry (ID: %s)", doc.Ref.ID)
 		}
+		// Update with the latest data from this user:
+		r.name = userName
+		r.email = userEmail
+		r.id = userID
 	} else {
 		// User is not subscribed, so provide a default recurser struct instead.
 		r = Recurser{
@@ -176,7 +152,7 @@ func (f *FirestoreRecurserDB) GetAllUsers(ctx context.Context) ([]Recurser, erro
 		if err != nil {
 			return nil, err
 		}
-		r, err = MapToStruct(doc.Data())
+		r, err = parseDoc(doc)
 		if err != nil {
 			log.Printf("error deserializing database entry with ID: %s: %s", doc.Ref.ID, err)
 			log.Printf("skipping database entry (ID: %s)", doc.Ref.ID)
@@ -189,7 +165,6 @@ func (f *FirestoreRecurserDB) GetAllUsers(ctx context.Context) ([]Recurser, erro
 }
 
 func (f *FirestoreRecurserDB) Set(ctx context.Context, userID int64, recurser Recurser) error {
-
 	r := recurser.ConvertToMap()
 	_, err := f.client.Collection("recursers").Doc(fmt.Sprintf("%d", userID)).Set(ctx, r, firestore.MergeAll)
 	return err
@@ -224,7 +199,7 @@ func (f *FirestoreRecurserDB) ListPairingTomorrow(ctx context.Context) ([]Recurs
 		if err != nil {
 			return nil, err
 		}
-		r, err = MapToStruct(doc.Data())
+		r, err = parseDoc(doc)
 		if err != nil {
 			log.Printf("error deserializing database entry with ID: %s: %s", doc.Ref.ID, err)
 			log.Printf("skipping database entry (ID: %s)", doc.Ref.ID)
@@ -252,7 +227,7 @@ func (f *FirestoreRecurserDB) ListSkippingTomorrow(ctx context.Context) ([]Recur
 			return nil, err
 		}
 
-		r, err = MapToStruct(doc.Data())
+		r, err = parseDoc(doc)
 		if err != nil {
 			log.Printf("error deserializing database entry with ID: %s: %s", doc.Ref.ID, err)
 			log.Printf("skipping database entry (ID: %s)", doc.Ref.ID)

--- a/database.go
+++ b/database.go
@@ -39,10 +39,8 @@ type Recurser struct {
 	email              string
 	isSkippingTomorrow bool
 	schedule           map[string]interface{}
-
-	// isSubscribed gets ignored in encoding; we only store subscribed individuals.
-	isSubscribed  bool `firestore:-`
-	currentlyAtRC bool
+	isSubscribed       bool
+	currentlyAtRC      bool
 }
 
 func (r *Recurser) ConvertToMap() map[string]interface{} {

--- a/database.go
+++ b/database.go
@@ -39,8 +39,10 @@ type Recurser struct {
 	email              string
 	isSkippingTomorrow bool
 	schedule           map[string]interface{}
-	isSubscribed       bool
-	currentlyAtRC      bool
+
+	// isSubscribed gets ignored in encoding; we only store subscribed individuals.
+	isSubscribed  bool `firestore:-`
+	currentlyAtRC bool
 }
 
 func (r *Recurser) ConvertToMap() map[string]interface{} {

--- a/database.go
+++ b/database.go
@@ -66,7 +66,11 @@ func MapToStruct(m map[string]interface{}) (Recurser, error) {
 	case uint8:
 	case uint16:
 	case uint32:
+		id = int64(v)
 	case uint64:
+		if v > (1<<31)-1 {
+			return Recurser{}, fmt.Errorf("ID value exceeds bounds: %d", v)
+		}
 		id = int64(v)
 	case string:
 		var err error
@@ -130,7 +134,7 @@ func (f *FirestoreRecurserDB) GetByUserID(ctx context.Context, userID int64, use
 		recurser["email"] = userEmail
 		r, err = MapToStruct(recurser)
 		if err != nil {
-			return Recurser{}, fmt.Errorf("getting database entry for recurser %s (ID: %d)", userName, userID)
+			return Recurser{}, fmt.Errorf("getting database entry for recurser %s (ID: %d): %w", userName, userID, err)
 		}
 	} else {
 		// User is not subscribed, so provide a default recurser struct instead.

--- a/dispatch.go
+++ b/dispatch.go
@@ -80,11 +80,19 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		accessToken, err := pl.adb.GetKey(ctx, "rc-accesstoken", "key")
 		if err != nil {
 			log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
+			response = writeErrorMessage
+			break
 		}
 
-		rec.currentlyAtRC = pl.rcapi.userIsCurrentlyAtRC(accessToken, userID)
+		rec.currentlyAtRC, err = pl.rcapi.userIsCurrentlyAtRC(accessToken, userID)
+		if err != nil {
+			log.Printf("Could not read currently-at-RC data from database: %s", err)
+			response = writeErrorMessage
+			break
+		}
 
 		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
+			log.Printf("Could not update from database: %s", err)
 			response = writeErrorMessage
 			break
 		}

--- a/dispatch.go
+++ b/dispatch.go
@@ -27,7 +27,7 @@ const notSubscribedMessage string = "You're not subscribed to Pairing Bot <3"
 var writeErrorMessage = fmt.Sprintf("Something went sideways while writing to the database. You should probably ping %v", owner)
 var readErrorMessage = fmt.Sprintf("Something went sideways while reading from the database. You should probably ping %v", owner)
 
-func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []string, userID string, userEmail string, userName string) (string, error) {
+func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []string, userID int64, userEmail string, userName string) (string, error) {
 	var response string
 	var err error
 
@@ -82,7 +82,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 			log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
 		}
 
-		rec.currentlyAtRC = pl.rcapi.userIsCurrentlyAtRC(accessToken, userEmail)
+		rec.currentlyAtRC = pl.rcapi.userIsCurrentlyAtRC(accessToken, userID)
 
 		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -18,7 +18,7 @@ var maintenanceMode = false
 
 // this is the "id" field from zulip, and is a permanent user ID that's not secret
 // Pairing Bot's owner can add their ID here for testing. ctrl+f "ownerID" to see where it's used
-const ownerID = "215391"
+const ownerID = 215391
 
 type PairingLogic struct {
 	rdb   RecurserDB
@@ -88,7 +88,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	log.Printf("The user: %s issued the following request to Pairing Bot: %s", userData.userEmail, pl.ur.getCommandString())
+	log.Printf("The user: %s (%d) issued the following request to Pairing Bot: %s", userData.userName, userData.userID, pl.ur.getCommandString())
 
 	// you *should* be able to throw any string at this thing and get back a valid command for dispatch()
 	// if there are no command arguments, cmdArgs will be nil
@@ -98,7 +98,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// the tofu and potatoes right here y'all
-	response, err := dispatch(ctx, pl, cmd, cmdArgs, userData.userID, userData.userEmail, userData.userName)
+	response, err := dispatch(ctx, pl, cmd, cmdArgs, int64(userData.userID), userData.userEmail, userData.userName)
 	if err != nil {
 		log.Println(err)
 	}
@@ -213,7 +213,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
 	}
 
-	emailsOfPeopleAtRc := pl.rcapi.getCurrentlyActiveEmails(accessToken)
+	idsOfPeopleAtRc := pl.rcapi.getCurrentlyActiveZulipIds(accessToken)
 
 	for i := 0; i < len(recursersList); i++ {
 
@@ -222,7 +222,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 		recurserEmail := recurser.email
 		recurserID := recurser.id
 
-		isAtRCThisWeek := contains(emailsOfPeopleAtRc, recurserEmail)
+		isAtRCThisWeek := contains(idsOfPeopleAtRc, recurserID)
 		wasAtRCLastWeek := recursersList[i].currentlyAtRC
 
 		log.Printf("User: %s was at RC last week: %t and is at RC this week: %t", recurserEmail, wasAtRCLastWeek, isAtRCThisWeek)

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -127,9 +127,9 @@ func parseCmd(cmdStr string) (string, []string, error) {
 	}
 }
 
-func contains(list []string, cmd string) bool {
+func contains[S ~[]E, E comparable](list S, element E) bool {
 	for _, v := range list {
-		if v == cmd {
+		if v == element {
 			return true
 		}
 	}


### PR DESCRIPTION
The history here is pretty messy -- sorry! Highlights:

- We already use Zulip ID as the database key.

  Ignore the "id" value in the database *value*, since it's redundant with the record ID.
  Alongside this, I slightly refactored how the record-to-struct conversion happens.

- Use the Zulip ID when sending messages.

  Empirically, list of IDs has to be given as `[123,456]`,
  i.e. with square brackets. It's fine to send a single-receiver message as `[123]`
  (Jeremy got the "odd one out" message).

- Retrieve the Zulip ID from the RC API, to use when handling end-of-batch processing


