### PR TITLE
dev: Add round-trip test for Recurser collection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,9 +6,6 @@ on:
       - main
       - dev
   pull_request:
-    branches:
-      - main
-      - dev
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,13 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - dev
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - dev
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,5 +25,20 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '>= 486.0.0'
+        install_components: 'cloud-firestore-emulator'
+
+    - name: Start Firestore emulator
+      run: |
+        gcloud emulators firestore start --host-port=[::1]:8410 &
+
+        until curl '[::1]:8410' 2>/dev/null; do
+            sleep 1
+        done
+
     - name: Test
       run: go test -v ./...
+      env:
+        FIRESTORE_EMULATOR_HOST: '[::1]:8410'

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"maps"
+	"math/big"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+)
+
+func fakeProjectID(t *testing.T) string {
+	return fmt.Sprintf("fake-project-%d", randInt64(t))
+}
+
+func randInt64(t *testing.T) int64 {
+	int64Max := int64(1<<63 - 1)
+
+	n, err := rand.Int(rand.Reader, big.NewInt(int64Max))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n.Int64()
+}
+
+func testFirestoreClient(t *testing.T, ctx context.Context, projectID string) *firestore.Client {
+	client, err := firestore.NewClient(ctx, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Logf("Error closing Firestore client: %v", err)
+		}
+	})
+
+	return client
+}
+
+func TestFirestoreRecurserDB(t *testing.T) {
+	t.Run("round-trip new recurser", func(t *testing.T) {
+		ctx := context.Background()
+		projectID := fakeProjectID(t)
+
+		client := testFirestoreClient(t, ctx, projectID)
+		recursers := &FirestoreRecurserDB{client}
+
+		recurser := Recurser{
+			id:                 randInt64(t),
+			name:               "Your Name",
+			email:              "test@recurse.example.net",
+			isSkippingTomorrow: false,
+			schedule: map[string]any{
+				"monday":    false,
+				"tuesday":   false,
+				"wednesday": false,
+				"thursday":  false,
+				"friday":    false,
+				"saturday":  false,
+				"sunday":    false,
+			},
+			isSubscribed:  false,
+			currentlyAtRC: false,
+		}
+
+		err := recursers.Set(ctx, recurser.id, recurser)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// GetByUserID forces isSubscribed to be `true`, because that's implied by
+		// the record's existence in the DB in the first place.
+		expected := recurser
+		expected.isSubscribed = true
+
+		// GetByUserID can update the name and email address if our record is stale.
+		// These values are the same, so this call *does not* trigger that update.
+		unchanged, err := recursers.GetByUserID(ctx, recurser.id, recurser.email, recurser.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !unchanged.Equal(expected) {
+			t.Errorf("values not equal:\nactual:   %+v\nexpected: %+v", unchanged, expected)
+		}
+
+		// These values are different, so this call *does* trigger an update.
+		changed, err := recursers.GetByUserID(ctx, recurser.id, "changed@recurse.example.net", "My Name")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected.email = "changed@recurse.example.net"
+		expected.name = "My Name"
+
+		if !changed.Equal(expected) {
+			t.Errorf("values not equal:\nactual:   %+v\nexpected: %+v", unchanged, expected)
+		}
+	})
+}
+
+func (r Recurser) Equal(s Recurser) bool {
+	return r.id == s.id &&
+		r.name == s.name &&
+		r.email == s.email &&
+		r.isSkippingTomorrow == s.isSkippingTomorrow &&
+		maps.Equal(r.schedule, s.schedule) &&
+		r.isSubscribed == s.isSubscribed &&
+		r.currentlyAtRC == s.currentlyAtRC
+}

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+exec gcloud emulators firestore start --host-port="$FIRESTORE_EMULATOR_HOST"


### PR DESCRIPTION
I want to be able to experiment with Pairing Bot locally, which means I'll need some way to run Firestore without also running all of Google Cloud. It turns out that there's an [emulator](https://cloud.google.com/firestore/docs/emulator) inside of `gcloud` which is made exactly for this purpose!

The Firestore Go SDK we're using automatically supports using this via the `FIRESTORE_EMULATOR_HOST` environment variable.

## Changes

This sets up a single round-trip test to prove that this all works. I left space to add more because I'll be collecting them in the future as I learn about how Firestore works (and how we use it!).

I also made these tests run on PRs to the `dev` branch. I intend to treat them as non-blocking there, but I do think it's nice to know that we've broken unit tests before deploying, even if it's just to the test bot.

I also added a `dev.sh` script to help me remember how to start the emulator. It uses the same variable as the SDK so something like [direnv](https://direnv.net/) makes it "just work".
