### PR TITLE
dev: Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-./pairing_bot
-.*
-TODO.txt
-*.bak
-pairing-bot
+# Compiled binary
+/pairing-bot
+/pairing_bot


### PR DESCRIPTION
The main reason for this PR is that the `.*` glob was causing some of my dev tools to miss the `.github` directory even though it *is* committed to the repo. That's the only line I *really* want to remove.

While I was here, I also removed the lines related to files that I didn't recognize. I'll gladly add any back in if they're important to common workflows, but I think most of these would make more sense in local repo config (the `.git/info/exclude` file) or in user-level Git config (the `core.excludesFile` setting).
