### PR TITLE
fix: Assume recurser ID is an int and document ID is a string

### DIFF
--- a/database.go
+++ b/database.go
@@ -17,7 +17,7 @@ import (
 
 // this is what we send to / receive from Firestore
 // var recurser = map[string]interface{}{
-// 	"id":                 "string",
+// 	"id":                 1234,
 // 	"name":               "string",
 // 	"email":              "string",
 // 	"isSkippingTomorrow": false,
@@ -251,7 +251,16 @@ func (f *FirestoreRecurserDB) UnsetSkippingTomorrow(ctx context.Context, recurse
 	r := recurser.ConvertToMap()
 	r["isSkippingTomorrow"] = false
 
-	_, err := f.client.Collection("recursers").Doc(r["id"].(string)).Set(ctx, r, firestore.MergeAll)
+	// There are two IDs that have to match:
+	//  1. The recurser ID *inside* the document, which is an int64.
+	//  2. The document ID *itself*, which is a string.
+	rID, ok := r["id"].(int64)
+	if !ok {
+		return fmt.Errorf(`recurser's "id" field was not an int64: %+v`, r)
+	}
+
+	docID := strconv.FormatInt(rID, 10)
+	_, err := f.client.Collection("recursers").Doc(docID).Set(ctx, r, firestore.MergeAll)
 	return err
 }
 


### PR DESCRIPTION
The cron jobs failed to run today because PB panicked while trying to un-skip someone for tomorrow.

[Zulip report](https://recurse.zulipchat.com/#narrow/stream/26440-small-questions/topic/pairing.20bot.20not.20matching.3F/near/462347012)

```
2024/08/14 04:00:01 server.go:3418: http: panic serving 127.0.0.1:38996: interface conversion: interface {} is int64, not string
...
main.(*FirestoreRecurserDB).UnsetSkippingTomorrow(0xc000062440, {0xcf20f8, 0xc00042c0a0}, {0xb2144, {0xc0004f62e0, 0x1b}, {0xc0001408b8, 0x17}, 0x1, 0xc0001e7080, ...})
    /layers/google.go.appengine-gomod/srv/database.go:254 +0x4a5
main.(*PairingLogic).match(0xc0000a6980, {0xcf0d70, 0xc00009e000}, 0xc000496000)
    /layers/google.go.appengine-gomod/srv/pairing_bot.go:136 +0x425
...
```

It looks like the issue is the assumption that the document ID == the recurser ID, but one is a string and the other is an int.

If this works (I don't have time to test it because I'm about to be traveling!), then it should be enough to manually run the pairing cron job again to make today's pairings.
