### PR TITLE
Log the random seed; use a random seed

### DIFF
--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -31,8 +31,6 @@ type PairingLogic struct {
 	rcapi RecurseAPI
 }
 
-var randSrc = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	var err error
 
@@ -139,8 +137,16 @@ func (pl *PairingLogic) match(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Reproducible randomness:
+	// - Get and log a random seed
+	// - Run the shuffle using a source derived from that seed
+	// so we can re-run the shuffle later, if needed.
+	// In dev, you should be able to set the seed below to get the same shuffle.
+	seed := rand.Int63()
+	log.Printf("Shuffling %d Recursers using random seed: %d", len(recursersList), seed)
+	randSrc := rand.NewSource(seed)
 	// shuffle our recursers. This will not error if the list is empty
-	randSrc.Shuffle(len(recursersList), func(i, j int) { recursersList[i], recursersList[j] = recursersList[j], recursersList[i] })
+	rand.New(randSrc).Shuffle(len(recursersList), func(i, j int) { recursersList[i], recursersList[j] = recursersList[j], recursersList[i] })
 
 	// if for some reason there's no matches today, we're done
 	if len(recursersList) == 0 {


### PR DESCRIPTION
Per report in Zulip, it seems like one Recurser has repeatedly been the
odd-one-out, i.e. the Recurser at the end of the list.

Prior to this change, the only entropy came from the start time. I don't
know whether that is considered a "good" seed; I'm suspicious that it
will have many bits the same from one day to another, and that could
result in some of the weirdness mentioned by a recurser.

With this change:

- Get a seed from the default randomness source.
- Log the seed, so (if we need to later debug a shuffle) we can patch it
  in. (In principle - ofc we'd have to run Pairing Bot locally for
  that...)
- Use that seed to create the shuffling RNG.

As I understand it, "seed a thread-local RNG from a thread-safe RNG" is
a pretty standard practice, and is relatively entropy-preserving.
