### PR TITLE
feat: Add version command

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -226,6 +226,8 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		response = getCookieClubMessage()
 	case "help":
 		response = helpMessage
+	case "version":
+		response = pl.version
 	default:
 		// this won't execute because all input has been sanitized
 		// by parseCmd() and all cases are handled explicitly above

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func Test_dispatch(t *testing.T) {
+	ctx := context.Background()
+	projectID := fakeProjectID(t)
+
+	client := testFirestoreClient(t, ctx, projectID)
+
+	pl := &PairingLogic{
+		rdb:     &FirestoreRecurserDB{client},
+		version: "test string",
+	}
+
+	t.Run("version", func(t *testing.T) {
+		resp, err := dispatch(ctx, pl, "version", nil, 0, "fake@recurse.example.net", "Your Name")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := "test string"
+		if resp != expected {
+			t.Errorf("expected %q, got %q", expected, resp)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func main() {
 
 	ctx := context.Background()
 
+	appVersion := os.Getenv("GAE_VERSION")
+
 	appEnv := os.Getenv("APP_ENV")
 	projectId := "pairing-bot-284823"
 	botUsername := "pairing-bot@recurse.zulipchat.com"
@@ -98,7 +100,8 @@ func main() {
 		rcapi: rcapi,
 		revdb: revdb,
 
-		zulip: zulipClient,
+		zulip:   zulipClient,
+		version: appVersion,
 	}
 
 	http.HandleFunc("/", http.NotFound)           // will this handle anything that's not defined?

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -30,7 +30,8 @@ type PairingLogic struct {
 	revdb ReviewDB
 	rcapi RecurseAPI
 
-	zulip *zulip.Client
+	zulip   *zulip.Client
+	version string
 }
 
 func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -30,6 +30,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		"add-review",
 		"get-reviews",
 		"cookie",
+		"version",
 	}
 
 	//This contains the days of the week and common abbreviations
@@ -116,6 +117,8 @@ func parseCmd(cmdStr string) (string, []string, error) {
 			}
 
 			return "schedule", userSchedule, err
+		case cmd[0] == "version":
+			return "version", nil, nil
 		default:
 			return cmd[0], cmd[1:], err
 		}

--- a/parse_cmd_test.go
+++ b/parse_cmd_test.go
@@ -31,6 +31,7 @@ var tableNoArgs = []struct {
 	{"help_wrong_usage", "help me", "help", nil, true},
 	{"status_correct_usage", "status", "status", nil, false},
 	{"status_wrong_usage", "status me", "help", nil, true},
+	{"version", "version", "version", nil, false},
 }
 
 func TestParseCmdNoArgs(t *testing.T) {
@@ -73,6 +74,7 @@ var tableWithArgs = []struct {
 	{"unskip_wrong_usage", "unskip today", "help", nil, true},
 	{"unskip_wrong_usage", "unskip friday", "help", nil, true},
 	{"unskip_wrong_usage", "unskip", "help", nil, true},
+	{"version_extra_args_ok", "version info", "version", nil, false},
 }
 
 func TestParseCmdWithArgs(t *testing.T) {
@@ -98,6 +100,8 @@ func TestParseCmdWithArgs(t *testing.T) {
 				if gotArgs[0] != "tomorrow" {
 					t.Errorf("Wrong argument %v for command %v\n", gotArgs[0], gotCmd)
 				}
+			case "version":
+				// Always fine as long as the wantedCmd check passes.
 			default:
 				if gotCmd != "help" {
 					t.Errorf("unknown command %v\n", gotCmd)


### PR DESCRIPTION
This reads the Google App Engine version from the environment and returns it in response to a new `version` command.

Ideally, we'd be able to get the current commit hash, but I haven't figured out a nice way to make that work through Cloud Build + App Engine. I suspect the answer is to start pushing our own Docker images, and that's something I don't want to do yet.

Since we don't currently name our GAE versions, we get timestamps (like `20240904t202224`). That's still good enough to show the difference between two builds.

## Test Plan

- [x] Works when pushed to `dev`!