### PR TITLE
dev: Add golangci-lint to Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +20,38 @@ jobs:
 
     - name: Build
       run: go build -v ./...
+
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read       # Read repo content
+      pull-requests: read  # Read PR base commit
+      checks: write        # Annotate code
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+          # Only report new issues introduced by *this* PR. Requires
+          # `permissons.pull-requests: read`.
+          only-new-issues: true
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
 
     - uses: google-github-actions/setup-gcloud@v2
       with:
@@ -39,3 +70,4 @@ jobs:
       run: go test -v ./...
       env:
         FIRESTORE_EMULATOR_HOST: '[::1]:8410'
+

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,10 @@
+[linters]
+enable = [
+    "asasalint",
+    "bidichk",
+    "bodyclose",
+    "durationcheck",
+    "gocheckcompilerdirectives",
+    "makezero",
+    "tenv",
+]

--- a/api.go
+++ b/api.go
@@ -94,7 +94,9 @@ func (ra *RecurseAPI) getCurrentlyActiveZulipIdsWithOffset(accessToken string, o
 
 	//Parse the json response from the API
 	recursers := []RecurserProfile{}
-	json.Unmarshal([]byte(body), &recursers)
+	if err := json.Unmarshal([]byte(body), &recursers); err != nil {
+		return nil, fmt.Errorf("unmarshal recursers: %w", err)
+	}
 
 	for i := range recursers {
 		zid := recursers[i].ZulipId
@@ -116,7 +118,10 @@ func (ra *RecurseAPI) isSecondWeekOfBatch(accessToken string) bool {
 
 	//Parse the json response from the API
 	var batches []map[string]interface{}
-	json.Unmarshal([]byte(body), &batches)
+	if err := json.Unmarshal([]byte(body), &batches); err != nil {
+		log.Printf("Error unmarshaling batches: %s", err)
+		return false
+	}
 
 	var batchStart string
 

--- a/database.go
+++ b/database.go
@@ -264,37 +264,6 @@ func (f *FirestoreRecurserDB) UnsetSkippingTomorrow(ctx context.Context, recurse
 	return err
 }
 
-// implements RecurserDB
-type MockRecurserDB struct{}
-
-func (m *MockRecurserDB) GetByUserID(ctx context.Context, userID int64, userEmail, userName string) (Recurser, error) {
-	return Recurser{}, nil
-}
-
-func (m *MockRecurserDB) GetAllUsers(ctx context.Context) ([]Recurser, error) {
-	return nil, nil
-}
-
-func (m *MockRecurserDB) Set(ctx context.Context, userID string, recurser Recurser) error {
-	return nil
-}
-
-func (m *MockRecurserDB) Delete(ctx context.Context, userID string) error {
-	return nil
-}
-
-func (m *MockRecurserDB) ListPairingTomorrow(ctx context.Context) ([]Recurser, error) {
-	return nil, nil
-}
-
-func (m *MockRecurserDB) ListSkippingTomorrow(ctx context.Context) ([]Recurser, error) {
-	return nil, nil
-}
-
-func (m *MockRecurserDB) UnsetSkippingTomorrow(ctx context.Context, userID string) error {
-	return nil
-}
-
 // DB Lookups of tokens
 
 type APIAuthDB interface {
@@ -314,13 +283,6 @@ func (f *FirestoreAPIAuthDB) GetKey(ctx context.Context, col, doc string) (strin
 
 	token := res.Data()
 	return token["value"].(string), nil
-}
-
-// implements APIAuthDB
-type MockAPIAuthDB struct{}
-
-func (f *MockAPIAuthDB) GetKey(ctx context.Context, col, doc string) (string, error) {
-	return "", nil
 }
 
 type PairingsDB interface {


### PR DESCRIPTION
There are a lot of Go linters out there that have saved me at least once, so I'd like to start running them here!

You can see what the report looks like on https://github.com/recursecenter/pairing-bot/pull/80/files

---

- **dev: Add golangci-lint step to Go workflow**
- **fix: Log unhandled errors**
- **refactor: Remove unused DB mocks**
