### PR TITLE
refactor: Use Firestore struct tags for auth tokens

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func fakeProjectID(t *testing.T) string {
@@ -122,4 +124,42 @@ func (r Recurser) Equal(s Recurser) bool {
 		maps.Equal(r.Schedule, s.Schedule) &&
 		r.IsSubscribed == s.IsSubscribed &&
 		r.CurrentlyAtRC == s.CurrentlyAtRC
+}
+
+func TestFirestoreAuthDB(t *testing.T) {
+	ctx := context.Background()
+	projectID := fakeProjectID(t)
+
+	client := testFirestoreClient(t, ctx, projectID)
+	auth := &FirestoreAPIAuthDB{client}
+
+	// Try to keep tests from conflicting with each other by adding a token
+	// that only this test knows about.
+	key := fmt.Sprintf("token-%d", randInt64(t))
+	val := fmt.Sprintf("secret-%d", randInt64(t))
+	doc := map[string]any{
+		"value": val,
+	}
+	_, err := client.Collection("testing").Doc(key).Set(ctx, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		_, err := auth.GetKey(ctx, "does-not", "exist")
+		if status.Code(err) != codes.NotFound {
+			t.Fatalf("expected NotFound error, got %#+v", err)
+		}
+	})
+
+	t.Run("present", func(t *testing.T) {
+		actual, err := auth.GetKey(ctx, "testing", key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if actual != val {
+			t.Errorf("values not equal:\nactual:   %+v\nexpected: %+v", actual, val)
+		}
+	})
 }

--- a/database_test.go
+++ b/database_test.go
@@ -146,14 +146,14 @@ func TestFirestoreAuthDB(t *testing.T) {
 	}
 
 	t.Run("missing", func(t *testing.T) {
-		_, err := auth.GetKey(ctx, "does-not", "exist")
+		_, err := auth.GetToken(ctx, "does-not/exist")
 		if status.Code(err) != codes.NotFound {
 			t.Fatalf("expected NotFound error, got %#+v", err)
 		}
 	})
 
 	t.Run("present", func(t *testing.T) {
-		actual, err := auth.GetKey(ctx, "testing", key)
+		actual, err := auth.GetToken(ctx, fmt.Sprintf("testing/%s", key))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dispatch.go
+++ b/dispatch.go
@@ -66,7 +66,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		accessToken, err := pl.adb.GetToken(ctx, "rc-accesstoken/key")
 		if err != nil {
 			log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
-			response = writeErrorMessage
+			response = readErrorMessage
 			break
 		}
 

--- a/dispatch.go
+++ b/dispatch.go
@@ -63,7 +63,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 			break
 		}
 
-		accessToken, err := pl.adb.GetKey(ctx, "rc-accesstoken", "key")
+		accessToken, err := pl.adb.GetToken(ctx, "rc-accesstoken/key")
 		if err != nil {
 			log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
 			response = writeErrorMessage

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -65,21 +64,9 @@ func main() {
 	}
 
 	zulipCredentials := func(ctx context.Context) (zulip.Credentials, error) {
-		res, err := db.Collection("apiauth").Doc("key").Get(ctx)
+		password, err := adb.GetToken(ctx, "apiauth/key")
 		if err != nil {
 			return zulip.Credentials{}, err
-		}
-
-		data := res.Data()
-
-		value, ok := data["value"]
-		if !ok {
-			return zulip.Credentials{}, errors.New(`missing key in /apiauth/key: "value"`)
-		}
-
-		password, ok := value.(string)
-		if !ok {
-			return zulip.Credentials{}, fmt.Errorf(`type mismatch in /apiauth/key: expected "value" to be string, got %T`, value)
 		}
 
 		return zulip.Credentials{

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -25,7 +25,7 @@ const ownerID = 215391
 
 type PairingLogic struct {
 	rdb   *FirestoreRecurserDB
-	adb   APIAuthDB
+	adb   *FirestoreAPIAuthDB
 	pdb   PairingsDB
 	revdb ReviewDB
 	rcapi RecurseAPI
@@ -46,7 +46,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("Handling a new Zulip request")
 
-	botAuth, err := pl.adb.GetKey(ctx, "botauth", "token")
+	botAuth, err := pl.adb.GetToken(ctx, "botauth/token")
 	if err != nil {
 		log.Println("Something weird happened trying to read the auth token from the database")
 	}
@@ -212,7 +212,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 		log.Println("Could not get list of recursers from DB: ", err)
 	}
 
-	accessToken, err := pl.adb.GetKey(ctx, "rc-accesstoken", "key")
+	accessToken, err := pl.adb.GetToken(ctx, "rc-accesstoken/key")
 	if err != nil {
 		log.Println("Something weird happened trying to read the RC API access token from the database: ", err)
 	}
@@ -329,7 +329,7 @@ func (pl *PairingLogic) welcome(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	accessToken, err := pl.adb.GetKey(ctx, "rc-accesstoken", "key")
+	accessToken, err := pl.adb.GetToken(ctx, "rc-accesstoken/key")
 	if err != nil {
 		log.Printf("Something weird happened trying to read the RC API access token from the database: %s", err)
 	}


### PR DESCRIPTION
This is the same as #81 but applied to the much smaller `FirestoreAPIAuthDB`.

The app treats these as read-only because they're essentially config secrets.

We always ask for them by full name, and those names are static strings, so I chose to use the full path as the argument instead of splitting the collection out like the previous interface.

## Test Plan

With the test bot, do something that requires loading each of the three tokens:

- [x] `"apiauth/key"` (make Zulip requests): `/match` job
- [x] `"botauth/token"` (verify inbound Zulip webhooks): `subscribe` commmand
- [x] `"rc-accesstoken/key"` (make RC requests): `subscribe` command

## Future Work

- These three collections (`apiauth`, `botauth`, `rc-accesstoken`) each contain a single document. I want to merge them into a `secrets` or `config` collection so that they're easier to keep track of.

- Continue doing this for more collections!
