### PR TITLE
refactor: Split dispatch into smaller functions

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []string, userID int64, userEmail string, userName string) (string, error) {
+func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []string, userID int64, userEmail string, userName string) (string, error) {
 	var response string
 	var err error
 

--- a/dispatch.go
+++ b/dispatch.go
@@ -40,12 +40,12 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 
 		rec.CurrentlyAtRC, err = pl.recurse.IsCurrentlyAtRC(ctx, userID)
 		if err != nil {
-			log.Printf("Could not read currently-at-RC data from database: %s", err)
-			return writeErrorMessage, err
+			log.Printf("Could not read currently-at-RC data from RC API: %s", err)
+			return readErrorMessage, err
 		}
 
 		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
-			log.Printf("Could not update from database: %s", err)
+			log.Printf("Could not update recurser in database: %s", err)
 			return writeErrorMessage, err
 		}
 		return subscribeMessage, nil

--- a/dispatch.go
+++ b/dispatch.go
@@ -28,80 +28,85 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 	case "schedule":
 		if !isSubscribed {
 			response = notSubscribedMessage
-			break
+			return response, err
 		}
 
 		rec.Schedule = newSchedule(cmdArgs)
 
 		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 		response = "Awesome, your new schedule's been set! You can check it with `status`."
+		return response, err
 
 	case "subscribe":
 		if isSubscribed {
 			response = "You're already subscribed! Use `schedule` to set your schedule."
-			break
+			return response, err
 		}
 
 		rec.CurrentlyAtRC, err = pl.recurse.IsCurrentlyAtRC(ctx, userID)
 		if err != nil {
 			log.Printf("Could not read currently-at-RC data from database: %s", err)
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 
 		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
 			log.Printf("Could not update from database: %s", err)
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 		response = subscribeMessage
+		return response, err
 
 	case "unsubscribe":
 		if !isSubscribed {
 			response = notSubscribedMessage
-			break
+			return response, err
 		}
 
 		if err := pl.rdb.Delete(ctx, userID); err != nil {
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 		response = unsubscribeMessage
+		return response, err
 
 	case "skip":
 		if !isSubscribed {
 			response = notSubscribedMessage
-			break
+			return response, err
 		}
 
 		rec.IsSkippingTomorrow = true
 
 		if err := pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 		response = `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`
+		return response, err
 
 	case "unskip":
 		if !isSubscribed {
 			response = notSubscribedMessage
-			break
+			return response, err
 		}
 		rec.IsSkippingTomorrow = false
 
 		if err := pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 		response = "Tomorrow: uncancelled! Heckin *yes*! **I will match you** for pairing tomorrow :)"
+		return response, err
 
 	case "status":
 		if !isSubscribed {
 			response = notSubscribedMessage
-			break
+			return response, err
 		}
 		// this particular days list is for sorting and printing the
 		// schedule correctly, since it's stored in a map in all lowercase
@@ -147,6 +152,8 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		}
 
 		response = fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr)
+		return response, err
+
 	case "add-review":
 		reviewContent := cmdArgs[0]
 
@@ -161,10 +168,12 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		if err != nil {
 			log.Println("Encountered an error when trying to save a review: ", err)
 			response = writeErrorMessage
-			break
+			return response, err
 		}
 
 		response = "Thank you for sharing your review with pairing bot!"
+		return response, err
+
 	case "get-reviews":
 		numReviews := 5
 
@@ -176,22 +185,30 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		if err != nil {
 			log.Printf("Encountered an error when trying to fetch the last %v reviews: %v", numReviews, err)
 			response = readErrorMessage
-			break
+			return response, err
 		}
 
 		response = "Here are some reviews of pairing bot:\n"
 		for _, rev := range lastN {
 			response += "* \"" + rev.content + "\"!\n"
 		}
+		return response, err
+
 	case "cookie":
 		response = cookieClubMessage
+		return response, err
+
 	case "help":
 		response = helpMessage
+		return response, err
+
 	case "version":
 		response = pl.version
+		return response, err
+
 	default:
 		// this won't execute because all input has been sanitized
 		// by parseCmd() and all cases are handled explicitly above
+		return response, err
 	}
-	return response, err
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -28,14 +28,7 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		return pl.Subscribe(ctx, rec)
 
 	case "unsubscribe":
-		if !isSubscribed {
-			return notSubscribedMessage, nil
-		}
-
-		if err := pl.rdb.Delete(ctx, userID); err != nil {
-			return writeErrorMessage, err
-		}
-		return unsubscribeMessage, nil
+		return pl.Unsubscribe(ctx, rec)
 
 	case "skip":
 		if !isSubscribed {
@@ -193,4 +186,15 @@ func (pl *PairingLogic) Subscribe(ctx context.Context, rec *Recurser) (string, e
 		return writeErrorMessage, err
 	}
 	return subscribeMessage, nil
+}
+
+func (pl *PairingLogic) Unsubscribe(ctx context.Context, rec *Recurser) (string, error) {
+	if !rec.IsSubscribed {
+		return notSubscribedMessage, nil
+	}
+
+	if err := pl.rdb.Delete(ctx, rec.ID); err != nil {
+		return writeErrorMessage, err
+	}
+	return unsubscribeMessage, nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -31,16 +31,7 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		return pl.Unsubscribe(ctx, rec)
 
 	case "skip":
-		if !isSubscribed {
-			return notSubscribedMessage, nil
-		}
-
-		rec.IsSkippingTomorrow = true
-
-		if err := pl.rdb.Set(ctx, userID, rec); err != nil {
-			return writeErrorMessage, err
-		}
-		return `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`, nil
+		return pl.SkipTomorrow(ctx, rec)
 
 	case "unskip":
 		if !isSubscribed {
@@ -197,4 +188,17 @@ func (pl *PairingLogic) Unsubscribe(ctx context.Context, rec *Recurser) (string,
 		return writeErrorMessage, err
 	}
 	return unsubscribeMessage, nil
+}
+
+func (pl *PairingLogic) SkipTomorrow(ctx context.Context, rec *Recurser) (string, error) {
+	if !rec.IsSubscribed {
+		return notSubscribedMessage, nil
+	}
+
+	rec.IsSkippingTomorrow = true
+
+	if err := pl.rdb.Set(ctx, rec.ID, rec); err != nil {
+		return writeErrorMessage, err
+	}
+	return `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`, nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -43,22 +43,10 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 
 	case "get-reviews":
 		numReviews := 5
-
 		if len(cmdArgs) > 0 {
 			numReviews, _ = strconv.Atoi(cmdArgs[0])
 		}
-
-		lastN, err := pl.revdb.GetLastN(ctx, numReviews)
-		if err != nil {
-			log.Printf("Encountered an error when trying to fetch the last %v reviews: %v", numReviews, err)
-			return readErrorMessage, err
-		}
-
-		response := "Here are some reviews of pairing bot:\n"
-		for _, rev := range lastN {
-			response += "* \"" + rev.content + "\"!\n"
-		}
-		return response, nil
+		return pl.GetReviews(ctx, numReviews)
 
 	case "cookie":
 		return cookieClubMessage, nil
@@ -210,4 +198,18 @@ func (pl *PairingLogic) AddReview(ctx context.Context, rec *Recurser, content st
 	}
 
 	return "Thank you for sharing your review with pairing bot!", nil
+}
+
+func (pl *PairingLogic) GetReviews(ctx context.Context, numReviews int) (string, error) {
+	lastN, err := pl.revdb.GetLastN(ctx, numReviews)
+	if err != nil {
+		log.Printf("Encountered an error when trying to fetch the last %v reviews: %v", numReviews, err)
+		return readErrorMessage, err
+	}
+
+	response := "Here are some reviews of pairing bot:\n"
+	for _, rev := range lastN {
+		response += "* \"" + rev.content + "\"!\n"
+	}
+	return response, nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -9,12 +9,7 @@ import (
 	"time"
 )
 
-func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []string, userID int64, userEmail string, userName string) (string, error) {
-	rec, err := pl.rdb.GetByUserID(ctx, userID, userEmail, userName)
-	if err != nil {
-		return readErrorMessage, err
-	}
-
+func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []string, rec *Recurser) (string, error) {
 	// here's the actual actions. command input from
 	// the user input has already been sanitized, so we can
 	// trust that cmd and cmdArgs only have valid stuff in them

--- a/dispatch.go
+++ b/dispatch.go
@@ -34,15 +34,7 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		return pl.SkipTomorrow(ctx, rec)
 
 	case "unskip":
-		if !isSubscribed {
-			return notSubscribedMessage, nil
-		}
-		rec.IsSkippingTomorrow = false
-
-		if err := pl.rdb.Set(ctx, userID, rec); err != nil {
-			return writeErrorMessage, err
-		}
-		return "Tomorrow: uncancelled! Heckin *yes*! **I will match you** for pairing tomorrow :)", nil
+		return pl.UnskipTomorrow(ctx, rec)
 
 	case "status":
 		if !isSubscribed {
@@ -201,4 +193,16 @@ func (pl *PairingLogic) SkipTomorrow(ctx context.Context, rec *Recurser) (string
 		return writeErrorMessage, err
 	}
 	return `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`, nil
+}
+
+func (pl *PairingLogic) UnskipTomorrow(ctx context.Context, rec *Recurser) (string, error) {
+	if !rec.IsSubscribed {
+		return notSubscribedMessage, nil
+	}
+	rec.IsSkippingTomorrow = false
+
+	if err := pl.rdb.Set(ctx, rec.ID, rec); err != nil {
+		return writeErrorMessage, err
+	}
+	return "Tomorrow: uncancelled! Heckin *yes*! **I will match you** for pairing tomorrow :)", nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -22,16 +22,7 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 	// trust that cmd and cmdArgs only have valid stuff in them
 	switch cmd {
 	case "schedule":
-		if !isSubscribed {
-			return notSubscribedMessage, nil
-		}
-
-		rec.Schedule = newSchedule(cmdArgs)
-
-		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
-			return writeErrorMessage, err
-		}
-		return "Awesome, your new schedule's been set! You can check it with `status`.", nil
+		return pl.SetSchedule(ctx, rec, cmdArgs)
 
 	case "subscribe":
 		if isSubscribed {
@@ -183,4 +174,17 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		// by parseCmd() and all cases are handled explicitly above
 		return "", nil
 	}
+}
+
+func (pl *PairingLogic) SetSchedule(ctx context.Context, rec *Recurser, days []string) (string, error) {
+	if !rec.IsSubscribed {
+		return notSubscribedMessage, nil
+	}
+
+	rec.Schedule = newSchedule(days)
+
+	if err := pl.rdb.Set(ctx, rec.ID, rec); err != nil {
+		return writeErrorMessage, err
+	}
+	return "Awesome, your new schedule's been set! You can check it with `status`.", nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -38,22 +38,8 @@ func (pl *PairingLogic) dispatch(ctx context.Context, cmd string, cmdArgs []stri
 		return pl.Status(ctx, rec)
 
 	case "add-review":
-		reviewContent := cmdArgs[0]
-
-		currentTimestamp := time.Now().Unix()
-
-		err = pl.revdb.Insert(ctx, Review{
-			content:   reviewContent,
-			timestamp: int(currentTimestamp),
-			email:     userEmail,
-		})
-
-		if err != nil {
-			log.Println("Encountered an error when trying to save a review: ", err)
-			return writeErrorMessage, err
-		}
-
-		return "Thank you for sharing your review with pairing bot!", nil
+		content := cmdArgs[0]
+		return pl.AddReview(ctx, rec, content)
 
 	case "get-reviews":
 		numReviews := 5
@@ -208,4 +194,20 @@ func (pl *PairingLogic) Status(ctx context.Context, rec *Recurser) (string, erro
 	}
 
 	return fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr), nil
+}
+
+func (pl *PairingLogic) AddReview(ctx context.Context, rec *Recurser, content string) (string, error) {
+	currentTimestamp := time.Now().Unix()
+
+	err := pl.revdb.Insert(ctx, Review{
+		content:   content,
+		timestamp: int(currentTimestamp),
+		email:     rec.Email,
+	})
+	if err != nil {
+		log.Println("Encountered an error when trying to save a review: ", err)
+		return writeErrorMessage, err
+	}
+
+	return "Thank you for sharing your review with pairing bot!", nil
 }

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -17,7 +17,7 @@ func Test_dispatch(t *testing.T) {
 	}
 
 	t.Run("version", func(t *testing.T) {
-		resp, err := dispatch(ctx, pl, "version", nil, 0, "fake@recurse.example.net", "Your Name")
+		resp, err := pl.dispatch(ctx, "version", nil, 0, "fake@recurse.example.net", "Your Name")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -16,8 +16,18 @@ func Test_dispatch(t *testing.T) {
 		version: "test string",
 	}
 
+	rec := &Recurser{
+		ID:                 0,
+		Name:               "Your Name",
+		Email:              "fake@recurse.example.net",
+		IsSkippingTomorrow: false,
+		Schedule:           map[string]bool{},
+		CurrentlyAtRC:      false,
+		IsSubscribed:       false,
+	}
+
 	t.Run("version", func(t *testing.T) {
-		resp, err := pl.dispatch(ctx, "version", nil, 0, "fake@recurse.example.net", "Your Name")
+		resp, err := pl.dispatch(ctx, "version", nil, rec)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -107,6 +107,16 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("The user: %s (%d) issued the following request to Pairing Bot: %s", hook.Message.SenderFullName, hook.Message.SenderID, hook.Data)
 
+	user, err := pl.rdb.GetByUserID(ctx, hook.Message.SenderID, hook.Message.SenderEmail, hook.Message.SenderFullName)
+	if err != nil {
+		log.Println(err)
+
+		if err = responder.Encode(zulip.Reply(readErrorMessage)); err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
 	// you *should* be able to throw any string at this thing and get back a valid command for dispatch()
 	// if there are no command arguments, cmdArgs will be nil
 	cmd, cmdArgs, err := parseCmd(hook.Data)
@@ -116,7 +126,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// the tofu and potatoes right here y'all
-	response, err := pl.dispatch(ctx, cmd, cmdArgs, hook.Message.SenderID, hook.Message.SenderEmail, hook.Message.SenderFullName)
+	response, err := pl.dispatch(ctx, cmd, cmdArgs, user)
 	if err != nil {
 		log.Println(err)
 		// Errors come with non-empty messages sometimes, so continue on.

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -116,7 +116,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// the tofu and potatoes right here y'all
-	response, err := dispatch(ctx, pl, cmd, cmdArgs, hook.Message.SenderID, hook.Message.SenderEmail, hook.Message.SenderFullName)
+	response, err := pl.dispatch(ctx, cmd, cmdArgs, hook.Message.SenderID, hook.Message.SenderEmail, hook.Message.SenderFullName)
 	if err != nil {
 		log.Println(err)
 		return

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -119,7 +119,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	response, err := pl.dispatch(ctx, cmd, cmdArgs, hook.Message.SenderID, hook.Message.SenderEmail, hook.Message.SenderFullName)
 	if err != nil {
 		log.Println(err)
-		return
+		// Errors come with non-empty messages sometimes, so continue on.
 	}
 
 	if err = responder.Encode(zulip.Reply(response)); err != nil {


### PR DESCRIPTION
While reading the `dispatch` function to learn how it works, I realized that all the switch cases are independent and don't really depend on the shared `response` and `err` variables. To make this clearer, I've given each command a dedicated method on `PairingLogic` and used those as case bodies.

This also gives us better testing hooks for individual commands, although I haven't written those tests yet.

Along the way, I discovered that my previous changes had dropped the "db error, ping someone" response, so this restores that too.

## Reviewer Notes

I recommend reviewing this by commits instead of all at once! I organized the changes as a bunch of tiny refactors that should be easy to verify because this code is currently hard to test.

These are all the non-refactor commits (i.e., behavior changes):

- **fix: Restore response on dispatch error**
- **fix: Use read error message text when fetching recurser data**
