### PR TITLE
refactor: Extract assert package from existing tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	cloud.google.com/go/firestore v1.14.0
+	github.com/google/go-cmp v0.6.0
 	google.golang.org/api v0.167.0
 	google.golang.org/grpc v1.62.0
 )

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,64 @@
+// Package assert provides test assertion helpers.
+//
+// Assertion functions report failures using t.Errorf to allow the containing
+// test to continue.
+//
+// Each function returns a bool indicating whether it was satisfied to support
+// conditional assertions.
+package assert
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Equal asserts that two values are equal.
+func Equal[T any](t *testing.T, got, want T) bool {
+	t.Helper()
+
+	diff := cmp.Diff(got, want)
+	if diff == "" {
+		return true
+	}
+
+	msg := "expected values to be equal"
+
+	t.Errorf("%s (-want +got):\n%s", msg, diff)
+	return false
+}
+
+// NoError asserts that err is nil.
+func NoError(t *testing.T, err error) bool {
+	t.Helper()
+
+	if err == nil {
+		return true
+	}
+
+	diff := fmt.Sprintf("- %v\n+ %#+v", nil, err)
+
+	msg := "expected error to be nil"
+
+	t.Errorf("%s (-want +got):\n%s", msg, diff)
+	return false
+}
+
+// ErrorAs asserts that an error in err's chain matches target using errors.As.
+func ErrorAs[E error](t *testing.T, err error) (E, bool) {
+	t.Helper()
+
+	var want E
+	if errors.As(err, &want) {
+		return want, true
+	}
+
+	diff := fmt.Sprintf("- %T\n+ %#+v\n+ e%q", want, err, err.Error())
+
+	msg := fmt.Sprintf("got error of type %T, wanted %T in error chain", err, want)
+
+	t.Errorf("%s (-want +got):\n%s", msg, diff)
+	return want, false
+}

--- a/parse_cmd_test.go
+++ b/parse_cmd_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"errors"
-	"reflect"
 	"testing"
+
+	"github.com/recursecenter/pairing-bot/internal/assert"
 )
 
 type parseResult struct {
@@ -64,8 +64,8 @@ func TestParseCmdAccept(t *testing.T) {
 				t.Fatalf("unexpected error: %#+v", err)
 			}
 
-			assertEqual(t, cmd, expected.Cmd)
-			assertEqual(t, args, expected.Args)
+			assert.Equal(t, cmd, expected.Cmd)
+			assert.Equal(t, args, expected.Args)
 		})
 	}
 }
@@ -109,28 +109,10 @@ func TestParseCmdReject(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			cmd, args, err := parseCmd(input)
 
-			_, _ = assertErrorAs[*parsingErr](t, err)
+			_, _ = assert.ErrorAs[*parsingErr](t, err)
 
-			assertEqual(t, cmd, "help")
-			assertEqual(t, args, nil)
+			assert.Equal(t, cmd, "help")
+			assert.Equal(t, args, nil)
 		})
 	}
-}
-
-func assertEqual[T any](t *testing.T, a, b T) {
-	t.Helper()
-
-	if reflect.DeepEqual(a, b) {
-		return
-	}
-
-	t.Errorf("expected %#+v to equal %#+v", a, b)
-}
-
-func assertErrorAs[T error](t *testing.T, err error) (target T, ok bool) {
-	ok = errors.As(err, &target)
-	if !ok {
-		t.Errorf("expected error as %T, got %#+v", target, err)
-	}
-	return target, ok
 }

--- a/recurse/client.go
+++ b/recurse/client.go
@@ -136,6 +136,10 @@ func (d *Datestamp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (d Datestamp) Equal(other Datestamp) bool {
+	return time.Time(d).Equal(time.Time(other))
+}
+
 // A Batch is a cycle of the Recurse Center retreat.
 //
 // https://github.com/recursecenter/wiki/wiki/Recurse-Center-API#Batches

--- a/recurse/client_test.go
+++ b/recurse/client_test.go
@@ -290,7 +290,7 @@ func TestClient_recurse_errors(t *testing.T) {
 	assert.Equal(t, err.Error(), "get active recursers (offset=0): error response from Recurse: 418 I'm a teapot")
 
 	if respErr, ok := assert.ErrorAs[*recurse.ResponseError](t, err); ok {
-		assert.Equal(t, 418, respErr.Response.StatusCode)
+		assert.Equal(t, respErr.Response.StatusCode, 418)
 
 		body, readErr := io.ReadAll(respErr.Response.Body)
 		if readErr != nil {

--- a/recurse/client_test.go
+++ b/recurse/client_test.go
@@ -4,49 +4,20 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"reflect"
 	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/recursecenter/pairing-bot/internal/assert"
 	"github.com/recursecenter/pairing-bot/recurse"
 )
-
-func assertEqual[T any](t *testing.T, expected, actual T) {
-	t.Helper()
-
-	if reflect.DeepEqual(expected, actual) {
-		return
-	}
-
-	t.Errorf("expected %#+v to equal %#+v", expected, actual)
-}
-
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err == nil {
-		return
-	}
-
-	t.Errorf("expected no error, got %#+v", err)
-}
-
-func assertErrorAs[T error](t *testing.T, err error) (target T, ok bool) {
-	ok = errors.As(err, &target)
-	if !ok {
-		t.Errorf("expected error as %T, got %#+v", target, err)
-	}
-	return target, ok
-}
 
 // MockServer wraps an httptest.Server to count the number of requests
 // received.
@@ -82,7 +53,7 @@ func (m *MockServer) AssertRequestCount(expected int) {
 	m.t.Helper()
 	m.Close()
 
-	assertEqual(m.t, int64(expected), m.requestCount.Load())
+	assert.Equal(m.t, m.requestCount.Load(), int64(expected))
 }
 
 func (m *MockServer) Close() {
@@ -143,8 +114,8 @@ func TestClient_ActiveRecursers(t *testing.T) {
 
 			pageIdx := 0
 			srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-				assertEqual(t, http.MethodGet, r.Method)
-				assertEqual(t, "/profiles", r.URL.Path)
+				assert.Equal(t, r.Method, http.MethodGet)
+				assert.Equal(t, r.URL.Path, "/profiles")
 
 				page := expectedPages[pageIdx]
 				pageIdx++
@@ -156,7 +127,7 @@ func TestClient_ActiveRecursers(t *testing.T) {
 					"offset":       []string{strconv.Itoa(page.Offset)},
 					"limit":        []string{strconv.Itoa(page.Limit)},
 				}
-				assertEqual(t, params, r.URL.Query())
+				assert.Equal(t, r.URL.Query(), params)
 
 				start := page.Offset
 				end := min(start+page.Limit, len(allProfiles))
@@ -184,7 +155,7 @@ func TestClient_ActiveRecursers(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assertEqual(t, profiles, allProfiles)
+			assert.Equal(t, profiles, allProfiles)
 		})
 	}
 }
@@ -208,13 +179,13 @@ func TestClient_AllBatches(t *testing.T) {
 	allBatches := loadJSON[[]recurse.Batch](t, "testdata/batches.json")
 
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-		assertEqual(t, http.MethodGet, r.Method)
-		assertEqual(t, "/batches", r.URL.Path)
+		assert.Equal(t, r.Method, http.MethodGet)
+		assert.Equal(t, r.URL.Path, "/batches")
 
 		params := url.Values{
 			"access_token": []string{"fake-access-token"},
 		}
-		assertEqual(t, params, r.URL.Query())
+		assert.Equal(t, r.URL.Query(), params)
 
 		err := json.NewEncoder(w).Encode(allBatches)
 		if err != nil {
@@ -239,15 +210,15 @@ func TestClient_AllBatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertEqual(t, batches, allBatches)
+	assert.Equal(t, batches, allBatches)
 }
 
 func TestClient_IsCurrentlyAtRC(t *testing.T) {
 	// This handler is easier than the one for ActiveRecursers because we know
 	// there's exactly one page to return.
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-		assertEqual(t, http.MethodGet, r.Method)
-		assertEqual(t, "/profiles", r.URL.Path)
+		assert.Equal(t, r.Method, http.MethodGet)
+		assert.Equal(t, r.URL.Path, "/profiles")
 
 		params := url.Values{
 			"access_token": []string{"fake-access-token"},
@@ -256,7 +227,7 @@ func TestClient_IsCurrentlyAtRC(t *testing.T) {
 			"offset":       []string{"0"},
 			"limit":        []string{"50"},
 		}
-		assertEqual(t, params, r.URL.Query())
+		assert.Equal(t, r.URL.Query(), params)
 
 		page := fakeProfiles(t, 25)
 
@@ -291,7 +262,7 @@ func TestClient_IsCurrentlyAtRC(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assertEqual(t, atRC, expected)
+			assert.Equal(t, atRC, expected)
 		})
 	}
 }
@@ -316,14 +287,17 @@ func TestClient_recurse_errors(t *testing.T) {
 	ctx := context.Background()
 
 	_, err = client.ActiveRecursers(ctx)
-	assertEqual(t, "get active recursers (offset=0): error response from Recurse: 418 I'm a teapot", err.Error())
+	assert.Equal(t, err.Error(), "get active recursers (offset=0): error response from Recurse: 418 I'm a teapot")
 
-	if respErr, ok := assertErrorAs[*recurse.ResponseError](t, err); ok {
-		assertEqual(t, 418, respErr.Response.StatusCode)
+	if respErr, ok := assert.ErrorAs[*recurse.ResponseError](t, err); ok {
+		assert.Equal(t, 418, respErr.Response.StatusCode)
 
 		body, readErr := io.ReadAll(respErr.Response.Body)
-		assertNoError(t, readErr)
-		assertEqual(t, "oops!", string(body))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+
+		assert.Equal(t, string(body), "oops!")
 	}
 
 	srv.AssertRequestCount(1)
@@ -334,12 +308,12 @@ func TestBatch_IsMini(t *testing.T) {
 
 	t.Run("mini batch", func(t *testing.T) {
 		batch := batches[2]
-		assertEqual(t, true, batch.IsMini())
+		assert.Equal(t, batch.IsMini(), true)
 	})
 
 	t.Run("not-mini batch", func(t *testing.T) {
 		batch := batches[0]
-		assertEqual(t, false, batch.IsMini())
+		assert.Equal(t, batch.IsMini(), false)
 	})
 }
 
@@ -374,7 +348,7 @@ func TestBatch_IsSecondWeek(t *testing.T) {
 	week2cron := must(time.Parse(time.RFC3339, "2024-05-28T14:00:00-04:00"))
 	week3cron := must(time.Parse(time.RFC3339, "2024-06-04T14:00:00-04:00"))
 
-	assertEqual(t, false, batch.IsSecondWeek(week1cron))
-	assertEqual(t, true, batch.IsSecondWeek(week2cron))
-	assertEqual(t, false, batch.IsSecondWeek(week3cron))
+	assert.Equal(t, batch.IsSecondWeek(week1cron), false)
+	assert.Equal(t, batch.IsSecondWeek(week2cron), true)
+	assert.Equal(t, batch.IsSecondWeek(week3cron), false)
 }

--- a/zulip/client_test.go
+++ b/zulip/client_test.go
@@ -2,45 +2,16 @@ package zulip_test
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"sync/atomic"
 	"testing"
 
+	"github.com/recursecenter/pairing-bot/internal/assert"
 	"github.com/recursecenter/pairing-bot/zulip"
 )
-
-func assertEqual[T any](t *testing.T, expected, actual T) {
-	t.Helper()
-
-	if reflect.DeepEqual(expected, actual) {
-		return
-	}
-
-	t.Errorf("expected %#+v to equal %#+v", expected, actual)
-}
-
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err == nil {
-		return
-	}
-
-	t.Errorf("expected no error, got %#+v", err)
-}
-
-func assertErrorAs[T error](t *testing.T, err error) (target T, ok bool) {
-	ok = errors.As(err, &target)
-	if !ok {
-		t.Errorf("expected error as %T, got %#+v", target, err)
-	}
-	return target, ok
-}
 
 // MockServer wraps an httptest.Server to count the number of requests
 // received.
@@ -76,7 +47,7 @@ func (m *MockServer) AssertRequestCount(expected int) {
 	m.t.Helper()
 	m.srv.Close()
 
-	assertEqual(m.t, int64(expected), m.requestCount.Load())
+	assert.Equal(m.t, m.requestCount.Load(), int64(expected))
 }
 
 func TestClient_PostToTopic(t *testing.T) {
@@ -110,14 +81,14 @@ func TestClient_PostToTopic(t *testing.T) {
 		t.Setenv("APP_ENV", "production")
 
 		srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			assertEqual(t, r.Method, http.MethodPost)
-			assertEqual(t, r.URL.Path, "/messages")
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/messages", r.URL.Path)
 
 			// Base64-encoding of "fake-username:fake-password"
 			authz := "Basic ZmFrZS11c2VybmFtZTpmYWtlLXBhc3N3b3Jk"
-			assertEqual(t, r.Header.Get("Authorization"), authz)
+			assert.Equal(t, r.Header.Get("Authorization"), authz)
 
-			assertEqual(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
+			assert.Equal(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
 
 			form := url.Values{
 				"type":    []string{"stream"},
@@ -125,8 +96,9 @@ func TestClient_PostToTopic(t *testing.T) {
 				"topic":   []string{"Pearing Bot"},
 				"content": []string{"Later, y'all!"},
 			}
-			assertNoError(t, r.ParseForm())
-			assertEqual(t, form, r.Form)
+			if assert.NoError(t, r.ParseForm()) {
+				assert.Equal(t, r.Form, form)
+			}
 		})
 
 		client, err := zulip.NewClient(
@@ -151,22 +123,23 @@ func TestClient_PostToTopic(t *testing.T) {
 
 func TestClient_SendUserMessage(t *testing.T) {
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-		assertEqual(t, r.Method, http.MethodPost)
-		assertEqual(t, r.URL.Path, "/messages")
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/messages", r.URL.Path)
 
 		// Base64-encoding of "fake-username:fake-password"
 		authz := "Basic ZmFrZS11c2VybmFtZTpmYWtlLXBhc3N3b3Jk"
-		assertEqual(t, r.Header.Get("Authorization"), authz)
+		assert.Equal(t, r.Header.Get("Authorization"), authz)
 
-		assertEqual(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
 
 		form := url.Values{
 			"type":    []string{"private"},
 			"to":      []string{"[0,1]"},
 			"content": []string{"Okay, go!"},
 		}
-		assertNoError(t, r.ParseForm())
-		assertEqual(t, form, r.Form)
+		if assert.NoError(t, r.ParseForm()) {
+			assert.Equal(t, r.Form, form)
+		}
 	})
 
 	client, err := zulip.NewClient(
@@ -208,14 +181,17 @@ func TestClient_zulip_errors(t *testing.T) {
 	ctx := context.Background()
 
 	err = client.SendUserMessage(ctx, []int64{0, 1}, "Okay, go!")
-	assertEqual(t, "error response from Zulip: 418 I'm a teapot", err.Error())
+	assert.Equal(t, err.Error(), "error response from Zulip: 418 I'm a teapot")
 
-	if respErr, ok := assertErrorAs[*zulip.ResponseError](t, err); ok {
-		assertEqual(t, 418, respErr.Response.StatusCode)
+	if respErr, ok := assert.ErrorAs[*zulip.ResponseError](t, err); ok {
+		assert.Equal(t, respErr.Response.StatusCode, 418)
 
 		body, readErr := io.ReadAll(respErr.Response.Body)
-		assertNoError(t, readErr)
-		assertEqual(t, "oops!", string(body))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+
+		assert.Equal(t, string(body), "oops!")
 	}
 
 	srv.AssertRequestCount(1)

--- a/zulip/client_test.go
+++ b/zulip/client_test.go
@@ -81,8 +81,8 @@ func TestClient_PostToTopic(t *testing.T) {
 		t.Setenv("APP_ENV", "production")
 
 		srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, http.MethodPost, r.Method)
-			assert.Equal(t, "/messages", r.URL.Path)
+			assert.Equal(t, r.Method, http.MethodPost)
+			assert.Equal(t, r.URL.Path, "/messages")
 
 			// Base64-encoding of "fake-username:fake-password"
 			authz := "Basic ZmFrZS11c2VybmFtZTpmYWtlLXBhc3N3b3Jk"
@@ -123,8 +123,8 @@ func TestClient_PostToTopic(t *testing.T) {
 
 func TestClient_SendUserMessage(t *testing.T) {
 	srv := mockServer(t, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/messages", r.URL.Path)
+		assert.Equal(t, r.Method, http.MethodPost)
+		assert.Equal(t, r.URL.Path, "/messages")
 
 		// Base64-encoding of "fake-username:fake-password"
 		authz := "Basic ZmFrZS11c2VybmFtZTpmYWtlLXBhc3N3b3Jk"


### PR DESCRIPTION
After the third copy-paste of assertEqual, I think it's time to make an internal test assertion library.

This is similar to [testify]'s assert package, mostly because it's the one I'm most familiar with.

This now uses [go-cmp] instead of `reflect.DeepEqual` for comparing values. We get free diff reports out of it too!

I added the package to a new `internal` directory to make it clear that this isn't part of the application itself. It also prevents it from being imported from anywhere else, even though there's no reason to import from this module anyway.

[go-cmp]: https://github.com/google/go-cmp
[testify]: https://github.com/stretchr/testify
