### PR TITLE
refactor: Rewrite the command parser

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -62,3 +62,19 @@ func ErrorAs[E error](t *testing.T, err error) (E, bool) {
 	t.Errorf("%s (-want +got):\n%s", msg, diff)
 	return want, false
 }
+
+// ErrorIs asserts that an error in err's chain matches target using errors.As.
+func ErrorIs(t *testing.T, got, want error) bool {
+	t.Helper()
+
+	if errors.Is(got, want) {
+		return true
+	}
+
+	diff := cmp.Diff(got, want)
+
+	msg := fmt.Sprintf("got error of type %T, wanted %T from unwrap", got, want)
+
+	t.Errorf("%s (-want +got):\n%s", msg, diff)
+	return false
+}

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -63,7 +63,7 @@ func ErrorAs[E error](t *testing.T, err error) (E, bool) {
 	return want, false
 }
 
-// ErrorIs asserts that an error in err's chain matches target using errors.As.
+// ErrorIs asserts that an error in err's chain matches target using errors.Is.
 func ErrorIs(t *testing.T, got, want error) bool {
 	t.Helper()
 

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -259,7 +260,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 
 		recurser := &recursersList[i]
 
-		isAtRCThisWeek := contains(idsOfPeopleAtRc, recurser.ID)
+		isAtRCThisWeek := slices.Contains(idsOfPeopleAtRc, recurser.ID)
 		wasAtRCLastWeek := recursersList[i].CurrentlyAtRC
 
 		log.Printf("User: %s was at RC last week: %t and is at RC this week: %t", recurser.Name, wasAtRCLastWeek, isAtRCThisWeek)

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -15,7 +15,6 @@ var ErrInvalidArguments = errors.New("invalid arguments")
 func parseCmd(cmdStr string) (string, []string, error) {
 	log.Println("The cmdStr is: ", cmdStr)
 
-	var err error
 	var cmdList = []string{
 		"subscribe",
 		"unsubscribe",
@@ -45,8 +44,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 	case len(cmd) == 0:
 		// This case is unreachable because strings.Split always returns at
 		// least one element.
-		err = errors.New("the user-issued command was blank")
-		return "help", nil, err
+		return "help", nil, errors.New("the user-issued command was blank")
 
 	// if there's a valid command and if there's no arguments
 	case contains(cmdList, cmd[0]) && len(cmd) == 1:
@@ -58,7 +56,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		case "add-review":
 			return "help", nil, fmt.Errorf(`%w: wanted review content`, ErrInvalidArguments)
 		}
-		return cmd[0], nil, err
+		return cmd[0], nil, nil
 
 	// if there's a valid command and there's some arguments
 	case contains(cmdList, cmd[0]) && len(cmd) > 1:
@@ -75,12 +73,12 @@ func parseCmd(cmdStr string) (string, []string, error) {
 					return "help", nil, fmt.Errorf(`%w: wanted a positive integer`, ErrInvalidArguments)
 				}
 			}
-			return "get-reviews", cmd[1:], err
+			return "get-reviews", cmd[1:], nil
 		case cmd[0] == "add-review":
 			//We manually split the input cmdStr here since the above code converts it to lower case
 			//and we want to presever the user's original formatting/casing
 			reviewArgs := strings.SplitN(cmdStr, " ", 2)
-			return "add-review", []string{reviewArgs[1]}, err
+			return "add-review", []string{reviewArgs[1]}, nil
 		case cmd[0] == "schedule":
 			var userSchedule []string
 
@@ -93,11 +91,11 @@ func parseCmd(cmdStr string) (string, []string, error) {
 				userSchedule = append(userSchedule, fullDayName)
 			}
 
-			return "schedule", userSchedule, err
+			return "schedule", userSchedule, nil
 		case cmd[0] == "version":
 			return "version", nil, nil
 		default:
-			return cmd[0], cmd[1:], err
+			return cmd[0], cmd[1:], nil
 		}
 
 	// if there's not a valid command

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -95,15 +95,6 @@ func parseCmd(cmdStr string) (string, []string, error) {
 	}
 }
 
-func contains[S ~[]E, E comparable](list S, element E) bool {
-	for _, v := range list {
-		if v == element {
-			return true
-		}
-	}
-	return false
-}
-
 var ErrUnknownDay = errors.New("unknown day abbreviation")
 
 // parseDay expands day name abbreviations into their canonical form.

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -33,28 +33,6 @@ func parseCmd(cmdStr string) (string, []string, error) {
 		"version",
 	}
 
-	//This contains the days of the week and common abbreviations
-	//so users can more easily set their schedules
-	dayAbbrevMap := map[string]string{
-		"monday":    "monday",
-		"mon":       "monday",
-		"tuesday":   "tuesday",
-		"tu":        "tuesday",
-		"tue":       "tuesday",
-		"wednesday": "wednesday",
-		"wed":       "wednesday",
-		"thursday":  "thursday",
-		"th":        "thursday",
-		"thu":       "thursday",
-		"thurs":     "thursday",
-		"friday":    "friday",
-		"fri":       "friday",
-		"saturday":  "saturday",
-		"sat":       "saturday",
-		"sunday":    "sunday",
-		"sun":       "sunday",
-	}
-
 	// convert the string to a slice
 	// after this, we have a value "cmd" of type []string
 	// where cmd[0] is the command and cmd[1:] are any arguments
@@ -110,12 +88,12 @@ func parseCmd(cmdStr string) (string, []string, error) {
 			var userSchedule []string
 
 			for _, day := range cmd[1:] {
-				if fullDayName, ok := dayAbbrevMap[day]; ok {
-					userSchedule = append(userSchedule, fullDayName)
-				} else {
-					err = &parsingErr{"the user issued SCHEDULE with malformed arguments"}
+				fullDayName, err := parseDay(day)
+				if err != nil {
 					return "help", nil, err
 				}
+
+				userSchedule = append(userSchedule, fullDayName)
 			}
 
 			return "schedule", userSchedule, err
@@ -139,4 +117,35 @@ func contains[S ~[]E, E comparable](list S, element E) bool {
 		}
 	}
 	return false
+}
+
+var ErrUnknownDay = errors.New("unknown day abbreviation")
+
+// parseDay expands day name abbreviations into their canonical form.
+func parseDay(word string) (string, error) {
+	switch strings.ToLower(word) {
+	case "mon", "monday":
+		return "monday", nil
+
+	case "tu", "tue", "tuesday":
+		return "tuesday", nil
+
+	case "wed", "wednesday":
+		return "wednesday", nil
+
+	case "th", "thu", "thurs", "thursday":
+		return "thursday", nil
+
+	case "fri", "friday":
+		return "friday", nil
+
+	case "sat", "saturday":
+		return "saturday", nil
+
+	case "sun", "sunday":
+		return "sunday", nil
+
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnknownDay, word)
+	}
 }

--- a/parse_cmd_test.go
+++ b/parse_cmd_test.go
@@ -71,37 +71,40 @@ func TestParseCmdAccept(t *testing.T) {
 }
 
 var rejectedCommands = map[string]error{
-	"": nil,
+	"": ErrUnknownCommand,
 
 	// Funnily enough: nil, these *do* give you what you want!
-	"help me":       nil,
-	"halp":          nil,
+	"help me":       ErrInvalidArguments,
+	"halp":          ErrUnknownCommand,
+	"schedule":      ErrInvalidArguments,
 	"schedule help": ErrUnknownDay,
 
 	// Unexpected arguments
-	"status me": nil,
-	"cookie me": nil,
+	"status me": ErrInvalidArguments,
+	"cookie me": ErrInvalidArguments,
 
 	// Did they really want `schedule`?
-	"subscribe tue":   nil,
-	"unsubscribe thu": nil,
+	"subscribe tue":   ErrInvalidArguments,
+	"unsubscribe thu": ErrInvalidArguments,
 
 	// (Un)skipping requires an argument.
-	"skip":   nil,
-	"unskip": nil,
+	"skip":   ErrInvalidArguments,
+	"unskip": ErrInvalidArguments,
 
 	// TODO(#49): Allow (un)skipping days other than tomorrow
-	"skip friday": nil,
-	"unskip next": nil,
+	"skip friday": ErrInvalidArguments,
+	"unskip next": ErrInvalidArguments,
 
 	// This is not the way to delete reviews you don't like 😛
-	"get-reviews -1":  nil,
-	"get-reviews -10": nil,
+	"get-reviews -1":  ErrInvalidArguments,
+	"get-reviews -10": ErrInvalidArguments,
+
+	"add-review": ErrInvalidArguments,
 
 	// Unknown commands
-	"scheduleing monday": nil,
-	"schedul monday":     nil,
-	"mooh":               nil,
+	"scheduleing monday": ErrUnknownCommand,
+	"schedul monday":     ErrUnknownCommand,
+	"mooh":               ErrUnknownCommand,
 }
 
 func TestParseCmdReject(t *testing.T) {
@@ -109,11 +112,7 @@ func TestParseCmdReject(t *testing.T) {
 		t.Run(input, func(t *testing.T) {
 			cmd, args, err := parseCmd(input)
 
-			if want == nil {
-				_, _ = assert.ErrorAs[*parsingErr](t, err)
-			} else {
-				assert.ErrorIs(t, err, want)
-			}
+			assert.ErrorIs(t, err, want)
 
 			assert.Equal(t, cmd, "help")
 			assert.Equal(t, args, nil)

--- a/parse_cmd_test.go
+++ b/parse_cmd_test.go
@@ -99,6 +99,8 @@ var rejectedCommands = map[string]error{
 	"get-reviews -1":  ErrInvalidArguments,
 	"get-reviews -10": ErrInvalidArguments,
 
+	"get-reviews 1 2": ErrInvalidArguments,
+
 	"add-review": ErrInvalidArguments,
 
 	// Unknown commands

--- a/parse_cmd_test.go
+++ b/parse_cmd_test.go
@@ -36,8 +36,8 @@ var acceptedCommands = map[string]parseResult{
 		[]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"},
 	},
 
-	// BUG(@jdkaplan): Don't squash spaces *inside* the review.
-	"add-review  :pear: ing    :robot:": {"add-review", []string{":pear: ing :robot:"}},
+	// Don't squash spaces *inside* the review.
+	"add-review  :pear: ing    :robot:": {"add-review", []string{":pear: ing    :robot:"}},
 
 	"get-reviews 0":  {"get-reviews", []string{"0"}},
 	"get-reviews 1":  {"get-reviews", []string{"1"}},


### PR DESCRIPTION
This is the big parser rewrite! I tried to do it in small chunks, but I relied a lot on the now-nearly-exhaustive test suite.
