### PR TITLE
refactor: Use Firestore struct tags for reviews

### DIFF
--- a/database.go
+++ b/database.go
@@ -226,7 +226,7 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 type Review struct {
 	Content   string `firestore:"content"`
 	Email     string `firestore:"email"`
-	Timestamp int    `firestore:"timestamp"`
+	Timestamp int64  `firestore:"timestamp"`
 }
 
 type ReviewDB interface {
@@ -257,7 +257,7 @@ func (f *FirestoreReviewDB) GetAll(ctx context.Context) ([]Review, error) {
 		currentReview := Review{
 			Content:   doc.Data()["content"].(string),
 			Email:     doc.Data()["email"].(string),
-			Timestamp: int(doc.Data()["timestamp"].(int64)),
+			Timestamp: doc.Data()["timestamp"].(int64),
 		}
 
 		allReviews = append(allReviews, currentReview)
@@ -282,7 +282,7 @@ func (f *FirestoreReviewDB) GetLastN(ctx context.Context, n int) ([]Review, erro
 		currentReview := Review{
 			Content:   doc.Data()["content"].(string),
 			Email:     doc.Data()["email"].(string),
-			Timestamp: int(doc.Data()["timestamp"].(int64)),
+			Timestamp: doc.Data()["timestamp"].(int64),
 		}
 
 		lastFive = append(lastFive, currentReview)

--- a/database.go
+++ b/database.go
@@ -224,9 +224,9 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 }
 
 type Review struct {
-	content   string
-	email     string
-	timestamp int
+	Content   string `firestore:"content"`
+	Email     string `firestore:"email"`
+	Timestamp int    `firestore:"timestamp"`
 }
 
 type ReviewDB interface {
@@ -255,9 +255,9 @@ func (f *FirestoreReviewDB) GetAll(ctx context.Context) ([]Review, error) {
 		}
 
 		currentReview := Review{
-			content:   doc.Data()["content"].(string),
-			email:     doc.Data()["email"].(string),
-			timestamp: int(doc.Data()["timestamp"].(int64)),
+			Content:   doc.Data()["content"].(string),
+			Email:     doc.Data()["email"].(string),
+			Timestamp: int(doc.Data()["timestamp"].(int64)),
 		}
 
 		allReviews = append(allReviews, currentReview)
@@ -280,9 +280,9 @@ func (f *FirestoreReviewDB) GetLastN(ctx context.Context, n int) ([]Review, erro
 		}
 
 		currentReview := Review{
-			content:   doc.Data()["content"].(string),
-			email:     doc.Data()["email"].(string),
-			timestamp: int(doc.Data()["timestamp"].(int64)),
+			Content:   doc.Data()["content"].(string),
+			Email:     doc.Data()["email"].(string),
+			Timestamp: int(doc.Data()["timestamp"].(int64)),
 		}
 
 		lastFive = append(lastFive, currentReview)
@@ -303,9 +303,9 @@ func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {
 
 func (f *FirestoreReviewDB) Insert(ctx context.Context, review Review) error {
 	_, _, err := f.client.Collection("reviews").Add(ctx, map[string]interface{}{
-		"content":   review.content,
-		"email":     review.email,
-		"timestamp": review.timestamp,
+		"content":   review.Content,
+		"email":     review.Email,
+		"timestamp": review.Timestamp,
 	})
 	return err
 }

--- a/database.go
+++ b/database.go
@@ -254,10 +254,10 @@ func (f *FirestoreReviewDB) GetAll(ctx context.Context) ([]Review, error) {
 			return nil, err
 		}
 
-		currentReview := Review{
-			Content:   doc.Data()["content"].(string),
-			Email:     doc.Data()["email"].(string),
-			Timestamp: doc.Data()["timestamp"].(int64),
+		var currentReview Review
+		if err := doc.DataTo(&currentReview); err != nil {
+			// TODO: log skip
+			continue
 		}
 
 		allReviews = append(allReviews, currentReview)
@@ -279,10 +279,10 @@ func (f *FirestoreReviewDB) GetLastN(ctx context.Context, n int) ([]Review, erro
 			return nil, err
 		}
 
-		currentReview := Review{
-			Content:   doc.Data()["content"].(string),
-			Email:     doc.Data()["email"].(string),
-			Timestamp: doc.Data()["timestamp"].(int64),
+		var currentReview Review
+		if err := doc.DataTo(&currentReview); err != nil {
+			// TODO: log skip
+			continue
 		}
 
 		lastFive = append(lastFive, currentReview)
@@ -302,11 +302,7 @@ func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {
 }
 
 func (f *FirestoreReviewDB) Insert(ctx context.Context, review Review) error {
-	_, _, err := f.client.Collection("reviews").Add(ctx, map[string]interface{}{
-		"content":   review.Content,
-		"email":     review.Email,
-		"timestamp": review.Timestamp,
-	})
+	_, _, err := f.client.Collection("reviews").Add(ctx, review)
 	return err
 }
 

--- a/database.go
+++ b/database.go
@@ -242,53 +242,17 @@ type FirestoreReviewDB struct {
 }
 
 func (f *FirestoreReviewDB) GetAll(ctx context.Context) ([]Review, error) {
-	var allReviews []Review
-
 	iter := f.client.Collection("reviews").Documents(ctx)
-	for {
-		doc, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		var currentReview Review
-		if err := doc.DataTo(&currentReview); err != nil {
-			// TODO: log skip
-			continue
-		}
-
-		allReviews = append(allReviews, currentReview)
-	}
-
-	return allReviews, nil
+	return fetchAll[Review](iter)
 }
 
 func (f *FirestoreReviewDB) GetLastN(ctx context.Context, n int) ([]Review, error) {
-	var lastFive []Review
-
-	iter := f.client.Collection("reviews").OrderBy("timestamp", firestore.Desc).Limit(n).Documents(ctx)
-	for {
-		doc, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		var currentReview Review
-		if err := doc.DataTo(&currentReview); err != nil {
-			// TODO: log skip
-			continue
-		}
-
-		lastFive = append(lastFive, currentReview)
-	}
-
-	return lastFive, nil
+	iter := f.client.
+		Collection("reviews").
+		OrderBy("timestamp", firestore.Desc).
+		Limit(n).
+		Documents(ctx)
+	return fetchAll[Review](iter)
 }
 
 func (f *FirestoreReviewDB) GetRandom(ctx context.Context) (Review, error) {

--- a/database_test.go
+++ b/database_test.go
@@ -116,6 +116,21 @@ func TestFirestoreRecurserDB(t *testing.T) {
 	})
 }
 
+func TestFirestoreReviewDB(t *testing.T) {
+	t.Run("round-trip content", func(t *testing.T) {
+		ctx := context.Background()
+		projectID := fakeProjectID(t)
+
+		client := testFirestoreClient(t, ctx, projectID)
+		reviews := &FirestoreReviewDB{client}
+		_ = reviews
+
+		t.Fatal("TODO: Write a review")
+		t.Fatal("TODO: Read the review")
+		t.Fatal("TODO: assert that the review matches")
+	})
+}
+
 func (r Recurser) Equal(s Recurser) bool {
 	return r.ID == s.ID &&
 		r.Name == s.Name &&

--- a/dispatch.go
+++ b/dispatch.go
@@ -183,9 +183,9 @@ func (pl *PairingLogic) AddReview(ctx context.Context, rec *Recurser, content st
 	currentTimestamp := time.Now().Unix()
 
 	err := pl.revdb.Insert(ctx, Review{
-		content:   content,
-		timestamp: int(currentTimestamp),
-		email:     rec.Email,
+		Content:   content,
+		Timestamp: int(currentTimestamp),
+		Email:     rec.Email,
 	})
 	if err != nil {
 		log.Println("Encountered an error when trying to save a review: ", err)
@@ -204,7 +204,7 @@ func (pl *PairingLogic) GetReviews(ctx context.Context, numReviews int) (string,
 
 	response := "Here are some reviews of pairing bot:\n"
 	for _, rev := range lastN {
-		response += "* \"" + rev.content + "\"!\n"
+		response += "* \"" + rev.Content + "\"!\n"
 	}
 	return response, nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -184,7 +184,7 @@ func (pl *PairingLogic) AddReview(ctx context.Context, rec *Recurser, content st
 
 	err := pl.revdb.Insert(ctx, Review{
 		Content:   content,
-		Timestamp: int(currentTimestamp),
+		Timestamp: currentTimestamp,
 		Email:     rec.Email,
 	})
 	if err != nil {

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -314,7 +314,7 @@ func (pl *PairingLogic) checkin(w http.ResponseWriter, r *http.Request) {
 		log.Println("Could not get a random review from DB: ", err)
 	}
 
-	checkinMessage, err := renderCheckin(time.Now(), numPairings, len(recursersList), review.content)
+	checkinMessage, err := renderCheckin(time.Now(), numPairings, len(recursersList), review.Content)
 	if err != nil {
 		log.Printf("Error when trying to render Pairing Bot checkin: %s", err)
 		return


### PR DESCRIPTION
This annotates the `Review` type with Firestore struct tags to make it easier to map back and forth between the struct and the document contents. This follows the pattern set by #81 and #82.

This also changes the `Timestamp` field from `int` to `int64` to match both places the type is relevant:
- Firestore represents integers as `int64`.
- The timestamps are Unix epoch times from Go's `time` library, which are also represented as `int64`.