### PR TITLE
dev: Switch to leveled logging for alerts

### DIFF
--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"slices"
@@ -245,9 +246,8 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 	profiles, err := pl.recurse.ActiveRecursers(ctx)
 	if err != nil {
 		log.Println("Encountered error while getting currently-active Recursers: ", err)
-		// TODO: https://github.com/recursecenter/pairing-bot/issues/61: Alert here!
-		// Using a FATAL here so it gets called out in the logs.
-		log.Fatal("Aborting end-of-batch processing!")
+		slog.Error("Aborting end-of-batch processing!")
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
Google Cloud supports [log-based alerts], especially if we start adding interesting fields to our logs (such as severity levels). The Go standard library now provides `log/slog` for structured (and leveled) logging, so let's start using it!

By default, the `slog` default logger also handles unstructured logs and emits them at "INFO" level. That's exactly what I would have done for most of our logs anyway, so we don't immediately have to change any code we already have.

But I _did_ choose to change one place: end-of-batch has a `log.Fatal` which is the same as `log.Info` + `os.Exit(1)`. Rather than exiting the whole process, I'd rather have it emit an error-level log and alert us. I also made it return an HTTP 500 response, so it still shows up as a failed cron job run.

[log-based alerts]: https://cloud.google.com/logging/docs/alerting/log-based-alerts
