### PR TITLE
fix: Move the welcome message to "current batches"

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,16 +44,20 @@ func main() {
 	appVersion := os.Getenv("GAE_VERSION")
 
 	appEnv := os.Getenv("APP_ENV")
+
 	projectId := "pairing-bot-284823"
 	botUsername := "pairing-bot@recurse.zulipchat.com"
+	welcomeStream := "current batches"
 
 	log.Printf("Running the app in environment = %s", appEnv)
 
-	//We have two pairing bot projects. One for production and one for testing/dev work.
+	// We have two pairing bot projects. One for production and one for testing/dev work.
 	if appEnv != "production" {
+		slog.Info("Setting dev/test config values")
+
 		projectId = "pairing-bot-dev"
 		botUsername = "dev-pairing-bot@recurse.zulipchat.com"
-		log.Println("Running pairing bot in the testing environment for development")
+		welcomeStream = "test-bot"
 	}
 
 	// Set up database wrappers. The Firestore client has a connection pool, so
@@ -119,6 +123,8 @@ func main() {
 		recurse: recurseClient,
 		zulip:   zulipClient,
 		version: appVersion,
+
+		welcomeStream: welcomeStream,
 	}
 
 	http.HandleFunc("/", http.NotFound)           // will this handle anything that's not defined?

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -52,6 +52,8 @@ type PairingLogic struct {
 	zulip   *zulip.Client
 	recurse *recurse.Client
 	version string
+
+	welcomeStream string
 }
 
 func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
@@ -325,12 +327,12 @@ func (pl *PairingLogic) checkin(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-/*
-Sends out a "Welcome to Pairing Bot" message to 397 Bridge during the second week of RC to introduce people to RC.
-
-We don't send this welcome message during the first week since it's a bit overwhelming with all of the orientation meetings
-and people haven't had time to think too much about their projects.
-*/
+// welcome sends a "Welcome to Pairing Bot" message to introduce the new batch
+// to Pairing Bot.
+//
+// We send this message during the second week of batch. The first week is a
+// bit overwhelming with all of the orientation meetings and messages, and
+// people haven't had time to think too much about their projects.
 func (pl *PairingLogic) welcome(w http.ResponseWriter, r *http.Request) {
 	// Check that the request is originating from within app engine
 	// https://cloud.google.com/appengine/docs/flexible/go/scheduling-jobs-with-cron-yaml#validating_cron_requests
@@ -369,7 +371,7 @@ func (pl *PairingLogic) welcome(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := pl.zulip.PostToTopic(ctx, "397 Bridge", "🍐🤖", msg); err != nil {
+		if err := pl.zulip.PostToTopic(ctx, pl.welcomeStream, "🍐🤖", msg); err != nil {
 			log.Printf("Error when trying to send welcome message about Pairing Bot %s\n", err)
 		}
 	}


### PR DESCRIPTION
Pairing Bot's welcome topic has been moved from "397 Bridge" to "current batches", so it's time to update the code to start posting there instead.

The test bot's posts get printed to the logs instead of actually being sent to Zulip. But just in case (or for some more realistic future integration testing?), I set the test bot welcome stream destination to the shared "test-bot" stream.
