### PR TITLE
refactor: Use Firestore struct tags for pairings

### DIFF
--- a/database.go
+++ b/database.go
@@ -178,8 +178,8 @@ func (f *FirestoreAPIAuthDB) GetToken(ctx context.Context, path string) (string,
 }
 
 type Pairing struct {
-	Value     int `firestore:"value"`
-	Timestamp int `firestore:"timestamp"`
+	Value     int   `firestore:"value"`
+	Timestamp int64 `firestore:"timestamp"`
 }
 
 type PairingsDB interface {
@@ -193,7 +193,7 @@ type FirestorePairingsDB struct {
 }
 
 func (f *FirestorePairingsDB) SetNumPairings(ctx context.Context, pairing Pairing) error {
-	timestampAsString := strconv.Itoa(pairing.Timestamp)
+	timestampAsString := strconv.FormatInt(pairing.Timestamp, 10)
 
 	_, err := f.client.Collection("pairings").Doc(timestampAsString).Set(ctx, map[string]interface{}{
 		"value":     pairing.Value,
@@ -220,7 +220,7 @@ func (f *FirestorePairingsDB) GetTotalPairingsDuringLastWeek(ctx context.Context
 
 		pairing := Pairing{
 			Value:     int(doc.Data()["value"].(int64)),
-			Timestamp: int(doc.Data()["timestamp"].(int64)),
+			Timestamp: doc.Data()["timestamp"].(int64),
 		}
 
 		log.Println("The timestamp is: ", pairing.Timestamp)

--- a/database_test.go
+++ b/database_test.go
@@ -221,7 +221,7 @@ func TestFirestorePairingsDB(t *testing.T) {
 		for i := 6; i >= 0; i-- {
 			err := pairings.SetNumPairings(ctx, Pairing{
 				Value:     5,
-				Timestamp: int(time.Now().Add(-time.Duration(i) * 24 * time.Hour).Unix()),
+				Timestamp: time.Now().Add(-time.Duration(i) * 24 * time.Hour).Unix(),
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/database_test.go
+++ b/database_test.go
@@ -8,8 +8,10 @@ import (
 	"math/big"
 	"strconv"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/recursecenter/pairing-bot/internal/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -204,5 +206,32 @@ func TestFirestoreAuthDB(t *testing.T) {
 		if actual != val {
 			t.Errorf("values not equal:\nactual:   %+v\nexpected: %+v", actual, val)
 		}
+	})
+}
+
+func TestFirestorePairingsDB(t *testing.T) {
+	t.Run("round trip weekly pairings", func(t *testing.T) {
+		ctx := context.Background()
+		projectID := fakeProjectID(t)
+
+		client := testFirestoreClient(t, ctx, projectID)
+		pairings := &FirestorePairingsDB{client}
+
+		// Entries representing pairings for each day of the week
+		for i := 6; i >= 0; i-- {
+			err := pairings.SetNumPairings(ctx, int(time.Now().Add(-time.Duration(i)*24*time.Hour).Unix()), 5)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		expected := 35
+
+		actual, err := pairings.GetTotalPairingsDuringLastWeek(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, actual, expected)
 	})
 }

--- a/database_test.go
+++ b/database_test.go
@@ -219,7 +219,10 @@ func TestFirestorePairingsDB(t *testing.T) {
 
 		// Entries representing pairings for each day of the week
 		for i := 6; i >= 0; i-- {
-			err := pairings.SetNumPairings(ctx, int(time.Now().Add(-time.Duration(i)*24*time.Hour).Unix()), 5)
+			err := pairings.SetNumPairings(ctx, Pairing{
+				Value:     5,
+				Timestamp: int(time.Now().Add(-time.Duration(i) * 24 * time.Hour).Unix()),
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -221,7 +221,7 @@ func (pl *PairingLogic) match(w http.ResponseWriter, r *http.Request) {
 
 	pairing := Pairing{
 		Value:     numRecursersPairedUp / 2,
-		Timestamp: int(time.Now().Unix()),
+		Timestamp: time.Now().Unix(),
 	}
 
 	if err := pl.pdb.SetNumPairings(ctx, pairing); err != nil {

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -219,10 +219,12 @@ func (pl *PairingLogic) match(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Pairing Bot paired up %d recursers today", numRecursersPairedUp)
 
-	numPairings := numRecursersPairedUp / 2
+	pairing := Pairing{
+		Value:     numRecursersPairedUp / 2,
+		Timestamp: int(time.Now().Unix()),
+	}
 
-	timestamp := time.Now().Unix()
-	if err := pl.pdb.SetNumPairings(ctx, int(timestamp), numPairings); err != nil {
+	if err := pl.pdb.SetNumPairings(ctx, pairing); err != nil {
 		log.Printf("Failed to record today's pairings: %s", err)
 	}
 }


### PR DESCRIPTION
This is the last collection for struct tag refactoring - `FirestorePairingsDB` - which closes #83!

- A new struct type `Pairing` is added on similar lines to the `Review` and `Recurser`  structs. This changes the parameters of `SetNumPairings` to use the new type. 
- The `Timestamp` field is changed from `int` to `int64` as both Go and Firestore store this value as `int64`, leading to fewer conversions.

I thought of using `fetchAll` in `GetTotalPairingsFromLastWeek` since the code is nearly the same. However using it would mean having to loop twice (once in `fetchAll` and once to add the pairing values), so I kept the function as is.