### PR TITLE
fix: Read secrets from new collection

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	}
 
 	zulipCredentials := func(ctx context.Context) (zulip.Credentials, error) {
-		password, err := adb.GetToken(ctx, "apiauth/key")
+		password, err := adb.GetToken(ctx, "secrets/zulip_api_key")
 		if err != nil {
 			return zulip.Credentials{}, err
 		}
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	recurseAccessToken := func(ctx context.Context) (recurse.AccessToken, error) {
-		token, err := adb.GetToken(ctx, "rc-accesstoken/key")
+		token, err := adb.GetToken(ctx, "secrets/recurse_access_token")
 		if err != nil {
 			return "", err
 		}

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -68,7 +68,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("Handling a new Zulip request")
 
-	botAuth, err := pl.adb.GetToken(ctx, "botauth/token")
+	botAuth, err := pl.adb.GetToken(ctx, "secrets/zulip_webhook_token")
 	if err != nil {
 		log.Println("Something weird happened trying to read the auth token from the database")
 	}


### PR DESCRIPTION
Pairing Bot holds many secrets, and some of them are config values!

Right now, those config secrets are stored in single-document collections that (in my experience) have names that don't clearly map to their usage.

This starts reading them all out of a new collection named "secrets", and each document contains a single secret token.

I've already copied the secrets to their new locations, which can be verified in the Google Cloud console for both environments. (The RC API access token won't match, though, because I generated a new one out of my RC account.)

After both the dev and prod bots deploy successfully, I'll delete the old unused secret collections.
