### PR TITLE
refactor: Extract AppEngine Cron source check into middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,12 +127,12 @@ func main() {
 		welcomeStream: welcomeStream,
 	}
 
-	http.HandleFunc("/", http.NotFound)           // will this handle anything that's not defined?
-	http.HandleFunc("/webhooks", pl.handle)       // from zulip
-	http.HandleFunc("/match", pl.match)           // from GCP- daily
-	http.HandleFunc("/endofbatch", pl.endofbatch) // from GCP- weekly
-	http.HandleFunc("/welcome", pl.welcome)       // from GCP- weekly
-	http.HandleFunc("/checkin", pl.checkin)       // from GCP- weekly
+	http.HandleFunc("/", http.NotFound)                 // will this handle anything that's not defined?
+	http.HandleFunc("/webhooks", pl.handle)             // from zulip
+	http.HandleFunc("/match", cron(pl.Match))           // from GCP- daily
+	http.HandleFunc("/endofbatch", cron(pl.EndOfBatch)) // from GCP- weekly
+	http.HandleFunc("/welcome", cron(pl.Welcome))       // from GCP- weekly
+	http.HandleFunc("/checkin", cron(pl.Checkin))       // from GCP- weekly
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+// JobFunc is the type of function that can run as a cron job.
+type JobFunc func(context.Context) error
+
+// cron wraps a job function to make it an HTTP handler. The handler enforces
+// that requests originate from App Engine's Cron scheduler.
+func cron(job JobFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Check that the request is originating from within app engine
+		// https://cloud.google.com/appengine/docs/standard/go/scheduling-jobs-with-cron-yaml#validating_cron_requests
+		if r.Header.Get("X-Appengine-Cron") != "true" {
+			http.NotFound(w, r)
+			return
+		}
+
+		err := job(r.Context())
+		if err != nil {
+			slog.Error("Job failed", slog.Any("error", err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/recursecenter/pairing-bot/internal/assert"
+)
+
+func Test_cron(t *testing.T) {
+	t.Run("run job for AppEngine", func(t *testing.T) {
+		// Arrange a cron job that tells us whether it ran.
+		ran := false
+		handler := cron(func(context.Context) error {
+			ran = true
+			return nil
+		})
+
+		// Prepare an AppEngine-sourced request.
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Appengine-Cron", "true")
+
+		// Run it!
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, ran, true)
+		assert.Equal(t, resp.StatusCode, 200)
+	})
+
+	t.Run("deny request outside of cron", func(t *testing.T) {
+		// Arrange a cron job that fails the test if it runs.
+		handler := cron(func(context.Context) error {
+			t.Error("handler should not have run")
+			return nil
+		})
+
+		// Prepare a request from outside of AppEngine (no custom header).
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		// Run it!
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, resp.StatusCode, 404)
+	})
+
+	t.Run("report job failure", func(t *testing.T) {
+		// Arrange a cron job that errors.
+		handler := cron(func(context.Context) error {
+			return errors.New("test error")
+		})
+
+		// Prepare an AppEngine-sourced request.
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Appengine-Cron", "true")
+
+		// Run it!
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, resp.StatusCode, 500)
+	})
+}


### PR DESCRIPTION
This de-duplicates the code we have to check the AppEngine Cron request header and pushes it into the HTTP router and out of the app logic.

As a convenient side effect, this also ensures that any cron job failure produces an HTTP 500 response (indicating failure to AppEngine) and an ERROR-severity log line (which we're starting to use for alerts).
