### PR TITLE
Move maintenanceMode to the PairingLogic struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 
 	if m, ok := os.LookupEnv("PB_MAINT"); ok {
 		if m == "true" {
-			maintenanceMode = true
+			pl.maintenanceMode = true
 		}
 	}
 

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -15,8 +15,6 @@ import (
 	"github.com/recursecenter/pairing-bot/zulip"
 )
 
-var maintenanceMode = false
-
 // maintainers contains the Zulip IDs of the current maintainers.
 //
 // This is a map instead of a slice to allow for easy membership checks.
@@ -49,9 +47,10 @@ type PairingLogic struct {
 	pdb   PairingsDB
 	revdb ReviewDB
 
-	zulip   *zulip.Client
-	recurse *recurse.Client
-	version string
+	zulip           *zulip.Client
+	recurse         *recurse.Client
+	version         string
+	maintenanceMode bool
 
 	welcomeStream string
 }
@@ -101,7 +100,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	// for testing only
 	// this responds with a maintenance message and quits if the request is coming from anyone other than a maintainer
-	if !isMaintainer(hook.Message.SenderID) && maintenanceMode {
+	if !isMaintainer(hook.Message.SenderID) && pl.maintenanceMode {
 		if err = responder.Encode(zulip.Reply(`pairing bot is down for maintenance`)); err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
Just a tiny change that @jdkaplan suggested to make `maintenanceMode` non-global.