### PR TITLE
fix: Use correct welcome stream name

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	projectId := "pairing-bot-284823"
 	botUsername := "pairing-bot@recurse.zulipchat.com"
-	welcomeStream := "current batches"
+	welcomeStream := "🧑‍💻 current batches" // The emoji is literally part of the channel name!
 
 	log.Printf("Running the app in environment = %s", appEnv)
 


### PR DESCRIPTION
I thought that the current batches channel name was just the text, but it really does include the emoji!

I found this out because Zulip messaged me this when PB tried to check in today:

> Your bot 'pairing-bot@recurse.zulipchat.com' tried to send a message to channel #**current batches**, but that channel does not exist. Click [here]() to create it.

I'll re-run the welcome job after merging.

For anyone with Google Cloud access, there's also [this alert](https://console.cloud.google.com/monitoring/alerting/alerts/0.njzjgu5x8ny0?channelType=mail&project=pairing-bot-284823) when the job failed. Yay, monitoring!