### PR TITLE
Go version upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/recursecenter/pairing-bot
 
-go 1.22.7
+go 1.23
 
 require (
 	cloud.google.com/go/firestore v1.17.0


### PR DESCRIPTION
- chore: go module upgrade
- chore: upgrade go version

Since apparently the just-module rev didn't build.
