### PR TITLE
fix: Remove overzealous pinning (gcloud doesn't have a version 1.22

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
   - name: 'go'
     path: '/gopath'
 
-- name: 'gcr.io/cloud-builders/gcloud:1.22'
+- name: 'gcr.io/cloud-builders/gcloud'
   args: ['app','deploy', 'cron.yaml']
   timeout: 600s
   env: ['GOPATH=/gopath']


### PR DESCRIPTION
This caused the prod push to fail. D'oh.